### PR TITLE
DM-9532: Establish MetricSet API and update Metric

### DIFF
--- a/python/lsst/verify/metric.py
+++ b/python/lsst/verify/metric.py
@@ -257,7 +257,8 @@ class Metric(JsonSerializationMixin):
         string representation. Use an empty string, ``''``, or
         ``astropy.units.dimensionless_unscaled`` for a unitless quantity.
     tags : `list` of `str`
-        Tags asssociated with this metric, to group it with similar metrics.
+        Tags associated with this metric. Tags are user-submitted string
+        tokens that are used to group metrics.
     reference_doc : `str`, optional
         The document handle that originally defined the metric
         (e.g., ``'LPM-17'``).
@@ -289,7 +290,11 @@ class Metric(JsonSerializationMixin):
         self.unit = u.Unit(unit)
         if tags is None:
             self.tags = []
+        elif isinstance(tags, basestring):
+            self.tags = [tags]
         else:
+            # FIXME DM-8477 Need type checking that tags are actually strings
+            # and are a set.
             self.tags = tags
         self.reference_doc = reference_doc
         self.reference_url = reference_url
@@ -314,6 +319,7 @@ class Metric(JsonSerializationMixin):
         # keyword args for Metric __init__
         args = {
             'unit': unit,
+            'tags': tags,
             # Remove trailing newline from folded block description field.
             # This isn't necessary if the field is trimmed with `>-` in YAML,
             # but won't hurt either.
@@ -346,6 +352,7 @@ class Metric(JsonSerializationMixin):
     def __eq__(self, other):
         return ((self.name == other.name) and
                 (self.unit == other.unit) and
+                (self.tags == other.tags) and
                 (self.description == other.description) and
                 (self.reference == other.reference))
 
@@ -434,6 +441,7 @@ class Metric(JsonSerializationMixin):
             'name': str(self.name),
             'description': self.description,
             'unit': self.unit_str,
+            'tags': self.tags,
             'reference': ref_doc})
 
     def check_unit(self, quantity):

--- a/python/lsst/verify/metric.py
+++ b/python/lsst/verify/metric.py
@@ -208,6 +208,31 @@ class MetricSet(object):
         for item in self._metrics.items():
             yield item
 
+    def subset(self, package_name):
+        """Create a new `MetricSet` with metrics belonging to a single
+        package.
+
+        Parameters
+        ----------
+        package_name : `str` or `lsst.verify.Name`
+            Name of the package to subset metrics by. If the package name
+            is ``'pkg_a'``, then metric ``'pkg_a.metric_1'`` would be
+            **included** in the subset, while ``'pkg_b.metric_2'`` would be
+            **excluded**.
+
+        Returns
+        -------
+        metric_subset : `MetricSet`
+            Subset of this metric set containing only metrics belonging
+            to the specified package.
+        """
+        if not isinstance(package_name, Name):
+            package_name = Name(package=package_name)
+
+        metrics = [metric for metric_name, metric in self._metrics.items()
+                   if metric_name in package_name]
+        return MetricSet(metrics)
+
 
 class Metric(JsonSerializationMixin):
     """Container for the definition of a metric.

--- a/python/lsst/verify/metric.py
+++ b/python/lsst/verify/metric.py
@@ -182,6 +182,16 @@ class MetricSet(object):
         for key in self._metrics:
             yield key
 
+    def __str__(self):
+        count = len(self)
+        if count == 0:
+            count_str = 'empty'
+        elif count == 1:
+            count_str = '1 Metric'
+        else:
+            count_str = '{count:d} Metrics'.format(count=count)
+        return '<MetricSet: {0}>'.format(count_str)
+
     def insert(self, metric):
         """Insert a `Metric` into the set.
 

--- a/python/lsst/verify/metric.py
+++ b/python/lsst/verify/metric.py
@@ -143,6 +143,33 @@ class MetricSet(object):
             key = Name(metric=key)
         return self._metrics[key]
 
+    def __setitem__(self, key, value):
+        if not isinstance(key, Name):
+            key = Name(metric=key)
+
+        # Key name must be for a metric
+        if not key.is_metric:
+            message = 'Key {0!r} is not a metric name'.format(key)
+            raise KeyError(message)
+
+        # value must be a metric type
+        if not isinstance(value, Metric):
+            message = 'Expected {0!s}={1!r} to be a Metric-type'.format(
+                key, value)
+            raise TypeError(message)
+
+        # Metric name and key name must be consistent
+        if value.name != key:
+            message = 'Key {0!s} inconsistent with Metric {0!s}'
+            raise KeyError(message.format(key, value))
+
+        self._metrics[key] = value
+
+    def __delitem__(self, key):
+        if not isinstance(key, Name):
+            key = Name(metric=key)
+        del self._metrics[key]
+
     def __len__(self):
         return len(self._metrics)
 
@@ -150,6 +177,36 @@ class MetricSet(object):
         if not isinstance(key, Name):
             key = Name(metric=key)
         return key in self._metrics
+
+    def __iter__(self):
+        for key in self._metrics:
+            yield key
+
+    def insert(self, metric):
+        """Insert a `Metric` into the set.
+
+        Any pre-existing metric with the same name is replaced
+
+        Parameters
+        ----------
+        metric : `Metric`
+            A metric.
+        """
+        self[metric.name] = metric
+
+    def items(self):
+        """Iterate over ``(name, metric)`` pairs in the set.
+
+        Yields
+        ------
+        item : tuple
+            Tuple containing:
+
+            - `Name` of the `Metric`
+            - `Metric` instance
+        """
+        for item in self._metrics.items():
+            yield item
 
 
 class Metric(JsonSerializationMixin):

--- a/python/lsst/verify/metric.py
+++ b/python/lsst/verify/metric.py
@@ -247,6 +247,8 @@ class Metric(JsonSerializationMixin):
 
     def __eq__(self, other):
         return ((self.name == other.name) and
+                (self.unit == other.unit) and
+                (self.description == other.description) and
                 (self.reference == other.reference))
 
     def __ne__(self, other):

--- a/python/lsst/verify/metric.py
+++ b/python/lsst/verify/metric.py
@@ -9,6 +9,7 @@ import yaml
 import astropy.units as u
 
 from .jsonmixin import JsonSerializationMixin
+from .naming import Name
 from .yamlutils import load_ordered_yaml
 
 __all__ = ['Metric', 'MetricSet', 'MetricRepo', 'load_metrics']
@@ -139,9 +140,6 @@ class Metric(JsonSerializationMixin):
         Page where metric in defined in the reference document.
     """
 
-    name = None
-    """Name of the metric (`str`)."""
-
     description = None
     """Short description of the metric (`str`)."""
 
@@ -265,6 +263,15 @@ class Metric(JsonSerializationMixin):
         return '{0.name} ({0.unit_str}): "{0.description}"'.format(self)
 
     @property
+    def name(self):
+        """Metric's name (`Name`)."""
+        return self._name
+
+    @name.setter
+    def name(self, value):
+        self._name = Name(metric=value)
+
+    @property
     def unit_str(self):
         """The string representation of the `Unit` of this metric."""
         if self.unit == '':
@@ -304,7 +311,7 @@ class Metric(JsonSerializationMixin):
             'page': self.reference_page,
             'url': self.reference_url}
         return JsonSerializationMixin.jsonify_dict({
-            'name': self.name,
+            'name': str(self.name),
             'description': self.description,
             'unit': self.unit,
             'reference': ref_doc})

--- a/python/lsst/verify/metric.py
+++ b/python/lsst/verify/metric.py
@@ -246,12 +246,6 @@ class Metric(JsonSerializationMixin):
                 reference_url=json_data['reference']['url'])
         return m
 
-    def check_unit(self, quantity):
-        """Check that quantity has equivalent units to this metric."""
-        if not quantity.unit.is_equivalent(self.unit):
-            return False
-        return True
-
     def __eq__(self, other):
         return ((self.name == other.name) and
                 (self.reference == other.reference))
@@ -315,6 +309,26 @@ class Metric(JsonSerializationMixin):
             'description': self.description,
             'unit': self.unit,
             'reference': ref_doc})
+
+    def check_unit(self, quantity):
+        """Check that a `~astropy.units.Quantity` has equivalent units to
+        this metric.
+
+        Parameters
+        ----------
+        quantity : `astropy.units.Quantity`
+            Quantity to be tested.
+
+        Returns
+        -------
+        is_equivalent : `bool`
+            `True` if the units are equivalent, meaning that the quantity
+            can be presented in the units of this metric. `False` if not.
+        """
+        if not quantity.unit.is_equivalent(self.unit):
+            return False
+        else:
+            return True
 
 
 def load_metrics(yaml_path):

--- a/tests/data/metrics/testing.yaml
+++ b/tests/data/metrics/testing.yaml
@@ -9,6 +9,7 @@ PA1:
   description: >
     The maximum rms of the unresolved source magnitude distribution around the
     mean value (repeatability).
+  tags: photometric
 
 PF1:
   reference:
@@ -18,15 +19,20 @@ PF1:
   unit: ''
   description: >
     The maximum fraction of magnitudes deviating by more than PA2 from mean (%).
+  tags: photometric
 
 PA2:
   unit: mmag
   description: >
     At most PF1 % of magnitudes may deviate by more than this from the mean
     (millimag).
+  tags: photometric
 
 AM1:
   unit: milliarcsecond
   description: >
     The maximum rms of the astrometric distance distribution for stellar pairs
     with separations of D=5 arcmin (repeatability) (milliarcsec).
+  tags:
+    - astrometric
+    - random-tag

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -5,18 +5,18 @@ import unittest
 
 import astropy.units as u
 
-from lsst.verify import Measurement, MeasurementSet, Metric, MetricSet
+from lsst.verify import Measurement, MeasurementSet, Metric, MetricSet, Name
 
 
 class MeasurementSetTestCase(unittest.TestCase):
+
     def setUp(self):
         package = 'test'
         self.package = package
         metric1 = Metric("{}.radius".format(package), "some radius", u.arcsec)
         metric2 = Metric("{}.cmodel_mag".format(package), "a magnitude", u.mag)
         metric3 = Metric("{}.unitless".format(package), "no units!", '')
-        self.metric_set = MetricSet(package,
-                                    metric_list=[metric1, metric2, metric3])
+        self.metric_set = MetricSet([metric1, metric2, metric3])
 
         self.good = {
             "{}.radius".format(package): .5*u.arcmin,
@@ -51,14 +51,13 @@ class MeasurementTestCase(unittest.TestCase):
         metric1 = Metric("{}.radius".format(package), "some radius", u.arcsec)
         metric2 = Metric("{}.cmodel_mag".format(package), "a magnitude", u.mag)
         metric3 = Metric("{}.unitless".format(package), "no units!", '')
-        self.metric_set = MetricSet(package,
-                                    metric_list=[metric1, metric2, metric3])
+        self.metric_set = MetricSet([metric1, metric2, metric3])
 
     def test_create_radius(self):
         metric = 'test.radius'
         value = 1235 * u.arcmin
         measurement = Measurement(metric, value, metric_set=self.metric_set)
-        self.assertEqual(measurement.name, metric)
+        self.assertEqual(measurement.name, Name(metric))
         self.assertEqual(measurement.value, value)
         self.assertEqual(measurement.description, "some radius")
 
@@ -66,7 +65,7 @@ class MeasurementTestCase(unittest.TestCase):
         metric = 'test.cmodel_mag'
         value = 1235 * u.mag
         measurement = Measurement(metric, value, metric_set=self.metric_set)
-        self.assertEqual(measurement.name, metric)
+        self.assertEqual(measurement.name, Name(metric))
         self.assertEqual(measurement.value, value)
         self.assertEqual(measurement.description, "a magnitude")
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -50,6 +50,26 @@ class MetricsPackageTestCase(unittest.TestCase):
             self.assertIsInstance(value, Metric)
         self.assertEqual(count, 4)
 
+    def test_tags(self):
+        """Both single string and tag lists are present in YAML."""
+        # Parsing this metric required putting the single tag inside a list
+        self.assertEqual(
+            len(self.metric_set['testing.PA1'].tags),
+            1)
+        self.assertIn(
+            'photometric',
+            self.metric_set['testing.PA1'].tags)
+
+        self.assertEqual(
+            len(self.metric_set['testing.AM1'].tags),
+            2)
+        self.assertIn(
+            'astrometric',
+            self.metric_set['testing.AM1'].tags)
+        self.assertIn(
+            'random-tag',
+            self.metric_set['testing.AM1'].tags)
+
     def test_setitem_delitem(self):
         """Test adding and deleting metrics."""
         m1 = Metric('validate_drp.test',
@@ -171,6 +191,7 @@ class MetricTestCase(unittest.TestCase):
         reference_page = 1
         reference_url = 'example.com'
         m = Metric(name, description, unit,
+                   tags=['tagA', 'tagB'],
                    reference_doc=reference_doc,
                    reference_url=reference_url,
                    reference_page=reference_page)
@@ -182,6 +203,9 @@ class MetricTestCase(unittest.TestCase):
         self.assertEqual(j['reference']['doc'], reference_doc)
         self.assertEqual(j['reference']['page'], reference_page)
         self.assertEqual(j['reference']['url'], reference_url)
+        self.assertIn('tagA', j['tags'])
+        self.assertIn('tagB', j['tags'])
+        self.assertNotIn('tagC', j['tags'])
 
         # rebuild from json
         m2 = Metric.deserialize(**j)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -104,6 +104,30 @@ class VerifyMetricsParsingTestCase(unittest.TestCase):
             MetricSet.load_metrics_package('nonexistent_metrics')
 
 
+class MetricSetSubsetTestCase(unittest.TestCase):
+    """Test case for MetricSet.subset."""
+
+    def setUp(self):
+        self.m1 = Metric('pkgA.m1', 'In pkgA', '')
+        self.m2 = Metric('pkgA.m2', 'In pkgA', '')
+        self.m3 = Metric('pkgB.m3', 'In pkgB', '')
+        self.metric_set = MetricSet([self.m1, self.m2, self.m3])
+
+    def test_subset_A(self):
+        subset = self.metric_set.subset('pkgA')
+        self.assertEqual(len(subset), 2)
+        self.assertIn(self.m1.name, subset)
+        self.assertIn(self.m2.name, subset)
+        self.assertNotIn(self.m3.name, subset)
+
+    def test_subset_B(self):
+        subset = self.metric_set.subset('pkgB')
+        self.assertEqual(len(subset), 1)
+        self.assertNotIn(self.m1.name, subset)
+        self.assertNotIn(self.m2.name, subset)
+        self.assertIn(self.m3.name, subset)
+
+
 class MetricTestCase(unittest.TestCase):
     """Test Metrics and metrics.yaml functionality."""
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -128,9 +128,9 @@ class MetricSetSubsetTestCase(unittest.TestCase):
     """Test case for MetricSet.subset."""
 
     def setUp(self):
-        self.m1 = Metric('pkgA.m1', 'In pkgA', '')
-        self.m2 = Metric('pkgA.m2', 'In pkgA', '')
-        self.m3 = Metric('pkgB.m3', 'In pkgB', '')
+        self.m1 = Metric('pkgA.m1', 'In pkgA', '', tags='testing')
+        self.m2 = Metric('pkgA.m2', 'In pkgA', '', tags='other')
+        self.m3 = Metric('pkgB.m3', 'In pkgB', '', tags='testing')
         self.metric_set = MetricSet([self.m1, self.m2, self.m3])
 
     def test_subset_A(self):
@@ -146,6 +146,20 @@ class MetricSetSubsetTestCase(unittest.TestCase):
         self.assertNotIn(self.m1.name, subset)
         self.assertNotIn(self.m2.name, subset)
         self.assertIn(self.m3.name, subset)
+
+    def test_subset_testing_tag(self):
+        subset = self.metric_set.subset(tag='testing')
+        self.assertEqual(len(subset), 2)
+        self.assertIn(self.m1.name, subset)
+        self.assertNotIn(self.m2.name, subset)
+        self.assertIn(self.m3.name, subset)
+
+    def test_subset_A_testing_tag(self):
+        subset = self.metric_set.subset(package='pkgA', tag='testing')
+        self.assertEqual(len(subset), 1)
+        self.assertIn(self.m1.name, subset)
+        self.assertNotIn(self.m2.name, subset)
+        self.assertNotIn(self.m3.name, subset)
 
 
 class MetricTestCase(unittest.TestCase):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -121,12 +121,7 @@ class MetricTestCase(unittest.TestCase):
 
         # rebuild from json
         m2 = Metric.from_json(j)
-        self.assertEqual(m.name, m2.name)
-        self.assertEqual(m.description, m2.description)
-        self.assertEqual(m.unit, m2.unit)
-        self.assertEqual(m.reference_doc, m2.reference_doc)
-        self.assertEqual(m.reference_page, m2.reference_page)
-        self.assertEqual(m.reference_url, m2.reference_url)
+        self.assertEqual(m, m2)
 
     def test_str(self):
         m1 = Metric('test', 'test docs', 'arcsec', reference_url='example.com',

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -137,6 +137,12 @@ class MetricTestCase(unittest.TestCase):
             str(m2),
             'test2 (dimensionless_unscaled): "some words"')
 
+    def test_check_unit(self):
+        m = Metric('test', '', 'marcsec')
+        self.assertTrue(m.check_unit(5. * u.arcsec))
+        self.assertTrue(m.check_unit(5. * u.marcsec))
+        self.assertFalse(m.check_unit(5. * u.mag))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -131,11 +131,12 @@ class MetricTestCase(unittest.TestCase):
     def test_str(self):
         m1 = Metric('test', 'test docs', 'arcsec', reference_url='example.com',
                     reference_doc='Doc', reference_page=1)
-        self.assertEqual(str(m1), 'test (arcsec): "test docs"')
+        self.assertEqual(str(m1), 'test (arcsec): test docs')
+
         m2 = Metric('test2', 'some words', '')
         self.assertEqual(
             str(m2),
-            'test2 (dimensionless_unscaled): "some words"')
+            'test2 (dimensionless_unscaled): some words')
 
     def test_check_unit(self):
         m = Metric('test', '', 'marcsec')


### PR DESCRIPTION
The goal of this refactor is to make MetricSet behave similarly to the SpecificationSet introduced in DM-9559 ( #4 ).

- MetricSet creation API matches SpecificationSet
- Metric uses Name classes internally for IDs
- Metric access from a MetricSet matches how specifications are accessed in SpecificationSet
- Check unit test (with setter and getter properties)
- Add tags to (de)serialization of Metrics
- Implement a `subset` method for MetricSet to get a MetricSet for a certain package and/or tag.