### PR TITLE
DM-10306: Metadata system and Metadata querying

### DIFF
--- a/python/lsst/verify/__init__.py
+++ b/python/lsst/verify/__init__.py
@@ -31,6 +31,7 @@ except:
 from .errors import *
 from .datum import *
 from .naming import *
+from .metaquery import *
 from .spec import *
 from .specset import *
 from .metric import *

--- a/python/lsst/verify/__init__.py
+++ b/python/lsst/verify/__init__.py
@@ -39,5 +39,6 @@ from .measurement import *
 from .measurementset import *
 from .blob import *
 from .blobset import *
+from .jobmetadata import *
 from .job import *
 from .output import *

--- a/python/lsst/verify/jobmetadata.py
+++ b/python/lsst/verify/jobmetadata.py
@@ -1,0 +1,192 @@
+#
+# LSST Data Management System
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# See COPYRIGHT file at the top of the source tree.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <https://www.lsstcorp.org/LegalNotices/>.
+#
+from __future__ import print_function
+
+__all__ = ['Metadata']
+
+# Get ChainMap backport
+from future.standard_library import install_aliases
+install_aliases()  # noqa: E402
+
+try:
+    from collections import ChainMap
+except ImportError:
+    # future 0.16.0 doesn't do the import right; this will be fixed in 0.16.1
+    # https://github.com/PythonCharmers/python-future/issues/226
+    from future.backports.misc import ChainMap
+import re
+
+from .jsonmixin import JsonSerializationMixin
+
+
+class Metadata(JsonSerializationMixin):
+    """Container for verification framework job metadata.
+
+    Metadata are key-value terms. Both keys and values should be
+    JSON-serializable.
+
+    Parameters
+    ----------
+    measurement_set : `lsst.verify.MeasurementSet`, optional
+        When provided, metadata with keys prefixed by metric names are
+        deferred to `Metadata` instances attached to measurements
+        (`lsst.verify.Measurement.meta`).
+    data : `dict`, optional
+        Dictionary to seed metadata with.
+    """
+
+    # Pattern for detecting metric name prefixes in names
+    _prefix_pattern = re.compile('^(\S+\.\S+)\.')
+
+    def __init__(self, measurement_set, data=None):
+
+        # Dict of job metadata not stored with a mesaurement
+        self._data = {}
+
+        # Measurement set to get measurement annotations from
+        self._meas_set = measurement_set
+
+        # Initialize the ChainMap. The first item in the chain map is the
+        # Metadata object's own _data. This is generic metadata. Additional
+        # items in the chain are Measurement.notes annotations for all
+        # measurements in the measurement_set.
+        self._chain = ChainMap(self._data)
+        self._cached_prefixes = set()
+        self._refresh_chainmap()
+
+        if data is not None:
+            self.update(data)
+
+    def _refresh_chainmap(self):
+        prefixes = set([str(name) for name in self._meas_set])
+
+        if self._cached_prefixes != prefixes:
+            self._cached_prefixes = prefixes
+
+            self._chain = ChainMap(self._data)
+            for _, measurement in self._meas_set.items():
+                # Get the dict instance directly so we don't use
+                # the MeasurementNotes's key auto-prefixing.
+                self._chain.maps.append(measurement.notes._data)
+
+    @staticmethod
+    def _get_prefix(key):
+        """Get the prefix of a measurement not, if it exists.
+
+        Examples
+        --------
+        >>> Metadata._get_prefix('note') is None
+        True
+        >>> Metadata._get_prefix('validate_drp.PA1.note')
+        'validate_drp.PA1.'
+
+        To get the metric name:
+
+        >>> prefix = Metadata._get_prefix('validate_drp.PA1.note')
+        >>> prefix.rstrip('.')
+        'validate_drp.PA1'
+        """
+        match = Metadata._prefix_pattern.match(key)
+        if match is not None:
+            return match.group(0)
+        else:
+            return None
+
+    def __getitem__(self, key):
+        self._refresh_chainmap()
+        return self._chain[key]
+
+    def __setitem__(self, key, value):
+        prefix = Metadata._get_prefix(key)
+        if prefix is not None:
+            metric_name = prefix.rstrip('.')
+            if metric_name in self._meas_set:
+                # turn prefix into a metric name
+                self._meas_set[metric_name].notes[key] = value
+                return
+
+        # No matching measurement; insert into general metadata
+        self._data[key] = value
+
+    def __delitem__(self, key):
+        prefix = Metadata._get_prefix(key)
+        if prefix is not None:
+            metric_name = prefix.rstrip('.')
+            if metric_name in self._meas_set:
+                del self._meas_set[metric_name].notes[key]
+                return
+
+        # No matching measurement; delete from general metadata
+        del self._data[key]
+
+    def __contains__(self, key):
+        self._refresh_chainmap()
+        return key in self._chain
+
+    def __len__(self):
+        self._refresh_chainmap()
+        return len(self._chain)
+
+    def __iter__(self):
+        self._refresh_chainmap()
+        for key in self._chain:
+            yield key
+
+    def __eq__(self, other):
+        # No explicit chain refresh because __len__ already does it
+        if len(self) != len(other):
+            return False
+
+        for key, value in other.items():
+            if key not in self:
+                return False
+            if value != self[key]:
+                return False
+
+        return True
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __str__(self):
+        return str(self._chain)
+
+    def __repr__(self):
+        return repr(self._chain)
+
+    def keys(self):
+        return [key for key in self]
+
+    def items(self):
+        self._refresh_chainmap()
+        for item in self._chain.items():
+            yield item
+
+    def update(self, data):
+        for key, value in data.items():
+            self[key] = value
+
+    @property
+    def json(self):
+        self._refresh_chainmap()
+        return self.jsonify_dict(self._chain)

--- a/python/lsst/verify/measurementset.py
+++ b/python/lsst/verify/measurementset.py
@@ -76,8 +76,12 @@ class MeasurementSet(JsonSerializationMixin):
 
         for meas_doc in measurements:
             if metric_set is not None:
-                metric = metric_set[meas_doc['metric']]
-                meas_doc['metric'] = metric
+                try:
+                    metric = metric_set[meas_doc['metric']]
+                    meas_doc['metric'] = metric
+                except KeyError:
+                    # metric not in the MetricSet, but it's optional
+                    pass
             meas = Measurement.deserialize(blobs=blob_set, **meas_doc)
             instance.insert(meas)
         return instance

--- a/python/lsst/verify/metaquery.py
+++ b/python/lsst/verify/metaquery.py
@@ -1,0 +1,111 @@
+#
+# LSST Data Management System
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# See COPYRIGHT file at the top of the source tree.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <https://www.lsstcorp.org/LegalNotices/>.
+#
+from __future__ import print_function, division
+
+__all__ = ['MetadataQuery']
+
+from .jsonmixin import JsonSerializationMixin
+
+
+class MetadataQuery(JsonSerializationMixin):
+    """Query of Job metadata.
+
+    Parameters
+    ----------
+    terms : `dict`, optional
+        A mapping of key-value query terms. A job's metadata must have all
+        these keys, and matching values, to pass the query.
+
+    Examples
+    --------
+    A MetadataQuery returns `True` if all keys-value terms found in
+    `MetadataQuery.terms` are equal to key-value metadata items.
+
+    >>> metadata = {'filter': 'r', 'camera': 'MegaCam'}
+
+    An example of a query with a conflicting term:
+
+    >>> query1 = MetadataQuery({'filter': 'r', 'camera': 'SDSS'})
+    >>> query1(metadata)
+    False
+
+    A query with matching terms (albeit, a subset of the metadata):
+
+    >>> query2 = MetadataQuery({'filter': 'r'})
+    >>> query2(metadata)
+    True
+
+    A query that overconstrains the available metadata:
+
+    >>> query3 = MetadataQuery({'filter': 'r', 'camera': 'MegaCam',
+    ...                         'photometric': True})
+    >>> query3(metadata)
+    False
+    """
+
+    terms = None
+    """Term mapping (`dict`). Metadata must have all keys and corresponding
+    values.
+    """
+
+    def __init__(self, terms=None):
+        self.terms = terms or dict()
+
+    def __call__(self, metadata):
+        """Determine if a metadata set matches the query terms.
+
+        Parameters
+        ----------
+        metadata : `dict` or `lsst.verify.Metadata`
+            Metadata mapping. Typically this is a job's
+            `lsst.verify.Job.meta`.
+
+        Returns
+        -------
+        match : `bool`
+            `True` if the metadata matches the query terms; `False` otherwise.
+        """
+        for term_key, term_value in self.terms.items():
+            if term_key not in metadata:
+                return False
+
+            # If metadata can be floats, may need to do more sophisticated
+            # comparison
+            if term_value != metadata[term_key]:
+                return False
+
+        return True
+
+    def __eq__(self, other):
+        return self.terms == other.terms
+
+    def __str__(self):
+        return str(self.terms)
+
+    def __repr__(self):
+        template = 'MetadataQuery({0!r})'
+        return template.format(self.terms)
+
+    @property
+    def json(self):
+        return self.jsonify_dict(self.terms)

--- a/python/lsst/verify/spec/base.py
+++ b/python/lsst/verify/spec/base.py
@@ -28,6 +28,7 @@ import abc
 from future.utils import with_metaclass
 
 from ..jsonmixin import JsonSerializationMixin
+from ..metaquery import MetadataQuery
 from ..naming import Name
 
 
@@ -54,6 +55,11 @@ class Specification(with_metaclass(abc.ABCMeta, JsonSerializationMixin)):
         if not self._name.is_spec:
             message = 'name {0!r} does not represent a specification'
             raise TypeError(message.format(self._name))
+
+        if 'metadata_query' in kwargs:
+            self.metadata_query = MetadataQuery(kwargs['metadata_query'])
+        else:
+            self.metadata_query = MetadataQuery()
 
     @property
     def name(self):
@@ -84,7 +90,8 @@ class Specification(with_metaclass(abc.ABCMeta, JsonSerializationMixin)):
             {
                 'name': str(self.name),
                 'type': self.type,
-                self.type: self._serialize_type()
+                self.type: self._serialize_type(),
+                'metadata_query': self.metadata_query
             }
         )
 
@@ -105,3 +112,20 @@ class Specification(with_metaclass(abc.ABCMeta, JsonSerializationMixin)):
             `False` otherwise.
         """
         pass
+
+    def query_metadata(self, metadata):
+        """Query a Job's metadata to determine if this specification applies.
+
+        Parameters
+        ----------
+        metadata : `lsst.verify.Metadata` or `dict`-type
+            Metadata mapping. Typically this is the `lsst.verify.Job.meta`
+            attribute.
+
+        Returns
+        -------
+        applies : `bool`
+            `True` if this specification applies to a Job's measurement, or
+            `False` otherwise.
+        """
+        return self.metadata_query(metadata)

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -35,7 +35,9 @@ class JobTestCase(unittest.TestCase):
     def setUp(self):
         # Mock metrics
         self.metric_photrms = Metric('test.PhotRms', 'Photometric RMS', 'mmag')
-        self.metric_set = MetricSet([self.metric_photrms])
+        self.metric_photmed = Metric('test.PhotMedian',
+                                     'Median magntidue', 'mag')
+        self.metric_set = MetricSet([self.metric_photrms, self.metric_photmed])
 
         # Mock specifications
         self.spec_photrms_design = ThresholdSpecification(
@@ -44,7 +46,9 @@ class JobTestCase(unittest.TestCase):
         self.spec_set = SpecificationSet([self.spec_photrms_design])
 
         # Mock measurements
-        self.meas_photrms = Measurement(self.metric_photrms, 15 * u.mmag)
+        self.meas_photrms = Measurement(
+            self.metric_photrms, 15 * u.mmag,
+            notes={'note': 'value'})
         self.meas_photrms.extras['n_stars'] = Datum(
             250,
             label='N stars',
@@ -61,6 +65,53 @@ class JobTestCase(unittest.TestCase):
         self.assertIn('test.PhotRms', job.metrics)
         self.assertIn('test.PhotRms', job.measurements)
 
+        # Test metadata access
+        self.assertIn('test.PhotRms.note', job.meta)
+        self.assertEqual(job.meta['test.PhotRms.note'], 'value')
+        # measurement metadata is always prefixed
+        self.assertNotIn('note', job.meta)
+
+        job.meta['job-level-key'] = 'yes'
+        self.assertEqual(job.meta['job-level-key'], 'yes')
+        self.assertIn('job-level-key', job.meta)
+
+        self.assertEqual(len(job.meta), 2)
+
+        job.meta.update({'test.PhotRms.note2': 'foo',
+                         'dataset': 'ci_hsc'})
+        # note2 should be in measurement notes
+        self.assertEqual(
+            job.measurements['test.PhotRms'].notes['note2'],
+            'foo')
+        self.assertEqual(job.meta['dataset'], 'ci_hsc')
+        # Delete measurement and job-level metadata
+        del job.meta['test.PhotRms.note2']
+        self.assertNotIn('test.PhotRms.note2', job.meta)
+        self.assertNotIn('note2', job.measurements['test.PhotRms'].notes)
+        del job.meta['dataset']
+        self.assertNotIn('dataset', job.meta)
+
+        self.assertEqual(
+            set(job.meta.keys()),
+            set(['job-level-key', 'test.PhotRms.note'])
+        )
+        self.assertEqual(
+            set([key for key in job.meta]),
+            set(['job-level-key', 'test.PhotRms.note'])
+        )
+        keys = set()
+        for key, value in job.meta.items():
+            keys.add(key)
+        self.assertEqual(keys, set(['job-level-key', 'test.PhotRms.note']))
+
+        # Add a new measurement
+        m = Measurement('test.PhotMedian', 28.5 * u.mag,
+                        notes={'aperture_corr': True})
+        job.measurements.insert(m)
+        self.assertIn('test.PhotMedian', job.measurements)
+        self.assertEqual(job.meta['test.PhotMedian.aperture_corr'], True)
+
+        # Test serialization
         json_doc = job.json
 
         self.assertIn('measurements', json_doc)
@@ -74,8 +125,22 @@ class JobTestCase(unittest.TestCase):
         self.assertIn('specs', json_doc)
         self.assertEqual(len(json_doc['specs']), len(job.specs))
 
+        self.assertIn('meta', json_doc)
+        self.assertEqual(len(json_doc['meta']), len(job.meta))
+
         new_job = Job.deserialize(**json_doc)
         self.assertEqual(job, new_job)
+
+        # check job-to-measurement metadata deserialization
+        self.assertEqual(
+            new_job.measurements['test.PhotRms'].notes['note'],
+            'value')
+        self.assertEqual(
+            new_job.meta['test.PhotRms.note'],
+            'value')
+        self.assertEqual(
+            new_job.meta['job-level-key'],
+            'yes')
 
 
 if __name__ == "__main__":

--- a/tests/test_specification_set.py
+++ b/tests/test_specification_set.py
@@ -338,7 +338,7 @@ class TestSpecificationSetLoadMetricsPackage(unittest.TestCase):
 
     def test_contains(self):
         self.assertTrue('validate_drp.PA1.design_gri' in self.spec_set)
-        self.assertTrue('validate_drp:cfht_gri#base' in self.spec_set)
+        self.assertTrue('validate_drp:cfht_gri/base#base' in self.spec_set)
 
 
 class TestSpecificationSetSubset(unittest.TestCase):

--- a/tests/test_specification_set.py
+++ b/tests/test_specification_set.py
@@ -341,8 +341,8 @@ class TestSpecificationSetLoadMetricsPackage(unittest.TestCase):
         self.assertTrue('validate_drp:cfht_gri/base#base' in self.spec_set)
 
 
-class TestSpecificationSetSubset(unittest.TestCase):
-    """Test creating subsets from a SpecificationSet."""
+class TestSpecificationSetNameSubset(unittest.TestCase):
+    """Test creating name-based subsets from a SpecificationSet."""
 
     def setUp(self):
         # defaults to validate_metrics
@@ -350,7 +350,7 @@ class TestSpecificationSetSubset(unittest.TestCase):
 
     def test_validate_drp_subset(self):
         package = Name('validate_drp')
-        subset = self.spec_set.subset('validate_drp')
+        subset = self.spec_set.subset(name='validate_drp')
 
         self.assertTrue(isinstance(subset, type(self.spec_set)))
         self.assertTrue(len(subset) > 0)
@@ -360,13 +360,66 @@ class TestSpecificationSetSubset(unittest.TestCase):
 
     def test_PA1_subset(self):
         metric = Name('validate_drp.PA1')
-        subset = self.spec_set.subset('validate_drp.PA1')
+        subset = self.spec_set.subset(name='validate_drp.PA1')
 
         self.assertTrue(isinstance(subset, type(self.spec_set)))
         self.assertTrue(len(subset) > 0)
 
         for spec_name, spec in subset._specs.items():
             self.assertTrue(spec_name in metric)
+
+
+class TestSpecificationSetMetadataSubset(unittest.TestCase):
+    """Test creating metadata-based or name and metadata-based subsets
+    from a SpecificationSet.
+    """
+
+    def setUp(self):
+        s1 = ThresholdSpecification(
+            Name('validate_drp.AM1.design_r'),
+            5. * u.marcsec, '<',
+            metadata_query={'filter_name': 'r'})
+        s2 = ThresholdSpecification(
+            Name('validate_drp.AM1.design_i'),
+            5. * u.marcsec, '<',
+            metadata_query={'filter_name': 'i'})
+        s3 = ThresholdSpecification(
+            Name('validate_drp.AM1.design_HSC_r'),
+            5. * u.marcsec, '<',
+            metadata_query={'filter_name': 'r', 'camera': 'HSC'})
+        s4 = ThresholdSpecification(
+            Name('validate_drp.PA1.design_r'),
+            10 * u.mmag, '<',
+            metadata_query={'filter_name': 'r'})
+        self.spec_set = SpecificationSet([s1, s2, s3, s4])
+
+    def test_metadata_subset(self):
+        """Subset by metadata only."""
+        subset = self.spec_set.subset(meta={'filter_name': 'r'})
+
+        self.assertIn('validate_drp.AM1.design_r', subset)
+        self.assertNotIn('validate_drp.AM1.design_i', subset)
+        self.assertNotIn('validate_drp.AM1.design_HSC_r', subset)
+        self.assertNotIn('validate_drp.PA1.design_HSC_r', subset)
+
+    def test_name_and_metadata_subset(self):
+        """Subset by name and metadata."""
+        subset = self.spec_set.subset(name='validate_drp.AM1',
+                                      meta={'filter_name': 'r'})
+
+        self.assertIn('validate_drp.AM1.design_r', subset)
+        self.assertNotIn('validate_drp.AM1.design_i', subset)
+        self.assertNotIn('validate_drp.AM1.design_HSC_r', subset)
+        self.assertNotIn('validate_drp.PA1.design_HSC_r', subset)
+
+    def test_name_subset(self):
+        """Subset by name."""
+        subset = self.spec_set.subset(name='validate_drp.AM1')
+
+        self.assertIn('validate_drp.AM1.design_r', subset)
+        self.assertIn('validate_drp.AM1.design_i', subset)
+        self.assertIn('validate_drp.AM1.design_HSC_r', subset)
+        self.assertNotIn('validate_drp.PA1.design_HSC_r', subset)
 
 
 if __name__ == "__main__":

--- a/tests/test_threshold_specification.py
+++ b/tests/test_threshold_specification.py
@@ -27,7 +27,7 @@ import operator
 
 import astropy.units as u
 
-from lsst.verify import Name
+from lsst.verify import Name, Job
 from lsst.verify.spec import ThresholdSpecification
 
 
@@ -180,6 +180,26 @@ class ThresholdSpecificationTestCase(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             ThresholdSpecification.convert_operator_str('<<'),
+
+    def test_query_metadata(self):
+        job = Job(meta={'filter_name': 'r',
+                        'camera': 'MegaCam'})
+        s1 = ThresholdSpecification(
+            Name('validate_drp.AM1.design_r'),
+            5. * u.marcsec, '<',
+            metadata_query={'filter_name': 'r'})
+        s2 = ThresholdSpecification(
+            Name('validate_drp.AM1.design_i'),
+            5. * u.marcsec, '<',
+            metadata_query={'filter_name': 'i'})
+        s3 = ThresholdSpecification(
+            Name('validate_drp.AM1.design_HSC_r'),
+            5. * u.marcsec, '<',
+            metadata_query={'filter_name': 'r', 'camera': 'HSC'})
+
+        self.assertTrue(s1.query_metadata(job.meta))
+        self.assertFalse(s2.query_metadata(job.meta))
+        self.assertFalse(s3.query_metadata(job.meta))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- `Measurement.notes` for measurement-level metadata. All keys here are automatically namespace by the metric name.
- `Job.meta` for Job-level metadata, including measurements. Using a `ChainMap`, one can access measurement metadata through `Job.meta`.
- `SpecificationSet.subset()` can now subset based on metadata. Effectively it provides a new `SpecificationSet` with only the specifications that apply to the Job.
- In Specification YAML files, `provenance_query` is renamed to `metadata_query`. The idea being that metadata is proactively set annotations, which is a potentially different thing than rigorous job provenance.