### PR TITLE
DM-10261: Create dispatch_verify.py CLI for uploading a verification job

### DIFF
--- a/bin.src/dispatch_verify.py
+++ b/bin.src/dispatch_verify.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+#
+# LSST Data Management System
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# See COPYRIGHT file at the top of the source tree.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <https://www.lsstcorp.org/LegalNotices/>.
+#
+
+from lsst.verify.bin.dispatchverify import main
+
+if __name__ == '__main__':
+    main()

--- a/python/lsst/verify/bin/__init__py
+++ b/python/lsst/verify/bin/__init__py
@@ -1,0 +1,22 @@
+#
+# LSST Data Management System
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# See COPYRIGHT file at the top of the source tree.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <https://www.lsstcorp.org/LegalNotices/>.
+#

--- a/python/lsst/verify/bin/dispatchverify.py
+++ b/python/lsst/verify/bin/dispatchverify.py
@@ -1,0 +1,371 @@
+#
+# LSST Data Management System
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# See COPYRIGHT file at the top of the source tree.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <https://www.lsstcorp.org/LegalNotices/>.
+#
+"""Upload LSST Science Pipelines Verification Job datasets to the SQUASH
+dashboard.
+
+Job JSON files can be created by `lsst.verify.Job.write()` or
+`lsst.verify.job.output_quantities()`. A Job dataset consists of metric
+measurements, associated blobs, and pipeline execution metadata. Individual
+LSST Science Pipelines tasks typically write separate JSON datasets. This
+command can collect and combine multiple Job JSON datasets into a single
+Job upload.
+
+Configuration
+=============
+
+dispatch_verify.py is configurable from both the command line and environment
+variables. See the argument documenation for environment variable equivalents.
+Command line settings override environment variable configuration.
+
+Metadata and environment
+========================
+
+dispatch_verify.py can enrich Verification Job metadata with information
+from the environment. In a Jenkins CI execution environment (``--env=ci``) the
+following environment variables are consumed:
+
+- ``BUILD_ID`` : ID in the ci system
+- ``BUILD_URL``: ci page with information about the build
+- ``PRODUCT``: the name of the product built, in this case 'validate_drp'
+- ``dataset``: the name of the dataset processed by validate_drp
+- ``label`` : the name of the platform where it runs
+
+If lsstsw is used, additional Git branch information is included with
+Science Pipelines package metadata.
+"""
+from __future__ import print_function
+
+import argparse
+import os
+import json
+
+try:
+    import git
+except ImportError:
+    # GitPython is not a standard Stack package; skip gracefully if unavailable
+    git = None
+
+import lsst.log
+from lsst.verify import Job
+from lsst.verify.metadata.lsstsw import LsstswRepos
+from lsst.verify.metadata.eupsmanifest import Manifest
+from lsst.verify.metadata.jenkinsci import get_jenkins_env
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog='More information is available at https://pipelines.lsst.io.')
+
+    parser.add_argument(
+        'json_paths',
+        nargs='+',
+        metavar='json',
+        help='Verificaton job JSON file, or files. When multiple JSON '
+             'files are present, their measurements, blobs, and metadata '
+             'are merged.')
+    parser.add_argument(
+        '--test',
+        default=False,
+        action='store_true',
+        help='Run this command without uploading to the SQUASH service. '
+             'The JSON payload is printed to standard out.')
+    parser.add_argument(
+        '--write',
+        metavar='PATH',
+        dest='output_filepath',
+        help='Write the merged and enriched Job JSON dataset to the given '
+             'path.')
+    parser.add_argument(
+        '--show',
+        dest='show_json',
+        action='store_true',
+        default=False,
+        help='Print the assembled Job JSON to standard output.')
+
+    env_group = parser.add_argument_group('Environment arguments')
+    env_group.add_argument(
+        '--env',
+        dest='env_name',
+        choices=Configuration.allowed_env,
+        help='Name of the environment where the verification job is being '
+             'run. In some environments display_verify.py will gather '
+             'additional metadata automatically. '
+             '**ci**: a ci.lsst.code (Jenkins job) environment. '
+             'Equivalent to the $VERIFY_ENV environment variable.')
+    env_group.add_argument(
+        '--lsstsw',
+        dest='lsstsw',
+        metavar='PATH',
+        help='lsstsw directory path. If available, Stack package versions are '
+             'read from lsstsw. Equivalent to the $LSSTSW environment '
+             'variable. Disabled with --ignore-lsstsw.')
+    env_group.add_argument(
+        '--package-repos',
+        dest='extra_package_paths',
+        nargs='*',
+        metavar='PATH',
+        help='Paths to additional Stack package Git repositories. These '
+             'packages are tracked in Job metadata, like lsstsw-based '
+             'packages.')
+    env_group.add_argument(
+        '--ignore-lsstsw',
+        dest='ignore_lsstsw',
+        action='store_true',
+        default=False,
+        help='Ignore lsstsw metadata even if it is available (for example, '
+             'the $LSSTSW variable is set).')
+
+    api_group = parser.add_argument_group('SQUASH API arguments')
+    api_group.add_argument(
+        '--url',
+        dest='api_url',
+        metavar='URL',
+        help='Root URL of the SQUASH API. Equivalent to the $SQUASH_URL '
+             'environment variable.')
+    api_group.add_argument(
+        '--user',
+        dest='api_user',
+        metavar='USER',
+        help='Username for SQUASH API. Equivalent to the $SQUASH_USER '
+             'environment variable.')
+    api_group.add_argument(
+        '--password',
+        dest='api_password',
+        metavar='PASSWORD',
+        help='Password for SQUASH API. Equivalent to the $SQUASH_PASSWORD '
+             'environment variable.')
+    return parser.parse_args()
+
+
+def main():
+    """Entrypoint for the ``dispatch_verify.py`` command line executable.
+    """
+    log = lsst.log.Log.getLogger('verify.bin.dispatchverify.main')
+
+    args = parse_args()
+    config = Configuration(args)
+    log.debug(str(config))
+
+    # Parse all Job JSON
+    jobs = []
+    for json_path in config.json_paths:
+        log.info('Loading {0}'.format(json_path))
+        with open(json_path) as fp:
+            json_data = json.load(fp)
+        job = Job.deserialize(**json_data)
+        jobs.append(job)
+
+    # Merge all Jobs into one
+    job = jobs.pop(0)
+    if len(jobs) > 0:
+        log.info('Merging verification Job JSON.')
+    for other_job in jobs:
+        job += other_job
+
+    # Ensure all measurements have a metric so that units are normalized
+    log.info('Refreshing metric definitions from verify_metrics')
+    job.reload_metrics_package('verify_metrics')
+
+    # Insert package metadata from lsstsw
+    if not config.ignore_lsstsw:
+        log.info('Inserting lsstsw package metadata from '
+                 '{0}.'.format(config.lsstsw))
+        job = insert_lsstsw_metadata(job, config)
+
+    # Insert metadata from additional specified packages
+    if config.extra_package_paths is not None:
+        job = insert_extra_package_metadata(job, config)
+
+    # Add environment variable metadata from the Jenkins CI environment
+    if config.env_name == 'jenkins':
+        log.info('Inserting Jenkins CI environment metadata.')
+        job = insert_jenkins_metadata(job, config)
+
+    # Upload job
+    if not config.test:
+        log.info('Uploading Job JSON to {0}.'.format(config.api_url))
+        job.dispatch(api_user=config.api_user,
+                     api_password=config.api_password,
+                     api_url=config.api_url)
+
+    if config.show_json:
+        print(json.dumps(job.json,
+                         sort_keys=True, indent=4, separators=(',', ': ')))
+
+    # Write a json file
+    if config.output_filepath is not None:
+        log.info('Writing Job JSON to {0}.'.format(config.output_filepath))
+        job.write(config.output_filepath)
+
+
+def insert_lsstsw_metadata(job, config):
+    """Insert metadata for lsstsw-based packages into ``Job.meta['packages']``.
+    """
+    lsstsw_repos = LsstswRepos(config.lsstsw)
+
+    with open(lsstsw_repos.manifest_path) as fp:
+        manifest = Manifest(fp)
+
+    packages = {}
+    for package_name, manifest_item in manifest.items():
+        package_doc = {
+            'name': package_name,
+            'git_branch': lsstsw_repos.get_package_branch(package_name),
+            'git_url': lsstsw_repos.get_package_repo_url(package_name),
+            'git_sha': manifest_item.git_sha,
+            'eups_version': manifest_item.version
+        }
+        packages[package_name] = package_doc
+
+    if 'packages' in job.meta:
+        # Extend packages entry
+        job.meta['packages'].update(packages)
+    else:
+        # Create new packages entry
+        job.meta['packages'] = packages
+    return job
+
+
+def insert_extra_package_metadata(job, config):
+    """Insert metadata for extra packages ('--package-repos') into
+    ``Job.meta['packages']``.
+    """
+    log = lsst.log.Log.getLogger(
+        'verify.bin.dispatchverify.insert_extra_package_metadata')
+
+    if 'packages' not in job.meta:
+        job.meta['packages'] = dict()
+
+    for package_path in config.extra_package_paths:
+        log.info('Inserting extra package metadata: {0}'.format(package_path))
+        package_name = package_path.split(os.sep)[-1]
+
+        package = {'name': package_name}
+
+        if git is not None:
+            git_repo = git.Repo(package_path)
+            package['git_sha'] = git_repo.active_branch.commit.hexsha
+            package['git_branch'] = git_repo.active_branch.name
+            package['git_url'] = git_repo.remotes.origin.url
+
+        if package_name in job.meta['packages']:
+            # Update pre-existing package metadata
+            job.meta['packages'][package_name].update(package)
+        else:
+            # Create new package metadata
+            job.meta['packages'][package_name] = package
+
+    return job
+
+
+def insert_jenkins_metadata(job, config):
+    """Insert metadata into the Job from the Jenkins environment.
+    """
+    jenkins_metadata = get_jenkins_env()
+    job.meta.update(jenkins_metadata)
+    return job
+
+
+class Configuration(object):
+    """Configuration for dispatch_verify.py that reconciles command line and
+    environment variable arguments.
+
+    Configuration is validated for completeness and certain errors.
+
+    Parameters
+    ----------
+    args : `argparse.Namespace`
+        Parsed command line arguments, produced by `parse_args`.
+    """
+
+    allowed_env = ('jenkins',)
+
+    def __init__(self, args):
+        self.json_paths = args.json_paths
+
+        self.test = args.test
+
+        self.output_filepath = args.output_filepath
+
+        self.show_json = args.show_json
+
+        self.env_name = args.env_name or os.getenv('VERIFY_ENV')
+        if self.env_name is not None and self.env_name not in self.allowed_env:
+            message = '$VERIFY_ENV not one of {0!s}'.format(self.allowed_env)
+            raise RuntimeError(message)
+
+        self.ignore_lsstsw = args.ignore_lsstsw
+
+        self.lsstsw = args.lsstsw or os.getenv('LSSTSW')
+        if self.lsstsw is not None:
+            self.lsstsw = os.path.abspath(self.lsstsw)
+        if not self.ignore_lsstsw and not os.path.isdir(self.lsstsw):
+            message = 'lsstsw directory not found at {0}'.format(self.lsstsw)
+            raise RuntimeError(message)
+
+        if args.extra_package_paths is not None:
+            self.extra_package_paths = [os.path.abspath(p)
+                                        for p in args.extra_package_paths]
+        else:
+            self.extra_package_paths = []
+        for path in self.extra_package_paths:
+            if not os.path.isdir(path):
+                message = 'Package directory not found: {0}'.format(path)
+                raise RuntimeError(message)
+
+        default_url = 'https://squash.lsst.codes/dashboard/api'
+        self.api_url = args.api_url or os.getenv('SQUASH_URL', default_url)
+
+        self.api_user = args.api_user or os.getenv('SQUASH_USER')
+        if not self.test and self.api_user is None:
+                message = '--user or $SQUASH_USER configuration required'
+                raise RuntimeError(message)
+
+        self.api_password = args.api_password or os.getenv('SQUASH_password')
+        if not self.test and self.api_password is None:
+                message = ('--password or $SQUASH_password configuration '
+                           'required')
+                raise RuntimeError(message)
+
+    def __str__(self):
+        configs = {
+            'json_paths': self.json_paths,
+            'test': self.test,
+            'output_filepath': self.output_filepath,
+            'show_json': self.show_json,
+            'env': self.env_name,
+            'ignore_lsstsw': self.ignore_lsstsw,
+            'lsstsw': self.lsstsw,
+            'extra_package_paths': self.extra_package_paths,
+            'api_url': self.api_url,
+            'api_user': self.api_user,
+        }
+        if self.api_password is None:
+            configs['api_password'] = None
+        else:
+            configs['api_password'] = '*' * len(self.api_password)
+
+        return json.dumps(configs,
+                          sort_keys=True, indent=4, separators=(',', ': '))

--- a/python/lsst/verify/job.py
+++ b/python/lsst/verify/job.py
@@ -241,6 +241,51 @@ class Job(JsonSerializationMixin):
         self.specs.update(other.specs)
         self.meta.update(other.meta)
         return self
+
+    def reload_metrics_package(self, package_name_or_path='verify_metrics',
+                               subset=None):
+        """Load a metrics package and add metric and specification definitions
+        to the Job, as well as the collected measurements.
+
+        Parameters
+        ----------
+        package_name_or_path : `str`, optional
+            Name of an EUPS package that hosts metric and specification
+            definition YAML files **or** the file path to a metrics package.
+            ``'verify_metrics'`` is the default package, and is where metrics
+            and specifications are defined for most packages.
+        subset : `str`, optional
+            If set, only metrics and specification for this package are loaded.
+            For example, if ``subset='validate_drp'``, only ``validate_drp``
+            metrics are included in the `MetricSet`. This argument is
+            equivalent to the `MetricSet.subset` method. Default is `None`.
+
+        Notes
+        -----
+        This method is useful for loading metric and specification definitions
+        into a job that was created without this information. In addition
+        to being added to `Job.metrics`, metrics are also attached to
+        `Job.measurements` items. This ensures that measurement values are
+        normalized into the units of the metric definition when a Job is
+        serialized.
+
+        See also
+        --------
+        MeasurementSet.refresh_metrics
+        """
+        metrics = MetricSet.load_metrics_package(
+            package_name_or_path=package_name_or_path,
+            subset=subset)
+        specs = SpecificationSet.load_metrics_package(
+            package_name_or_path=package_name_or_path,
+            subset=subset)
+
+        self.metrics.update(metrics)
+        self.specs.update(specs)
+
+        # Insert mertics into measurements
+        self.measurements.refresh_metrics(metrics)
+
     def write(self, filename):
         """Write a JSON serialization to the filesystem.
 

--- a/python/lsst/verify/job.py
+++ b/python/lsst/verify/job.py
@@ -223,6 +223,24 @@ class Job(JsonSerializationMixin):
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    def __iadd__(self, other):
+        """Merge another Job into this one.
+
+        Parameters
+        ----------
+        other : `Job`
+            Job instance to be merged into this one.
+
+        Returns
+        -------
+        self : `Job`
+            This `Job` instance.
+        """
+        self.measurements.update(other.measurements)
+        self.metrics.update(other.metrics)
+        self.specs.update(other.specs)
+        self.meta.update(other.meta)
+        return self
     def write(self, filename):
         """Write a JSON serialization to the filesystem.
 

--- a/python/lsst/verify/measurementset.py
+++ b/python/lsst/verify/measurementset.py
@@ -136,6 +136,28 @@ class MeasurementSet(JsonSerializationMixin):
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    def __iadd__(self, other):
+        """Merge another `MeasurementSet` into this one.
+
+        Parameters
+        ---------
+        other : `MeasurementSet`
+            Another `MeasurementSet`. Measurements in ``other`` that do
+            exist in this set are added to this one. Measurements in
+            ``other`` replace measurements of the same metric in this one.
+
+        Returns
+        -------
+        self : `MeasurementSet`
+            This `MeasurementSet`.
+
+        Notes
+        -----
+        Equivalent to `update`.
+        """
+        self.update(other)
+        return self
+
     def __str__(self):
         count = len(self)
         if count == 0:
@@ -163,6 +185,19 @@ class MeasurementSet(JsonSerializationMixin):
     def insert(self, measurement):
         """Insert a measurement into the set."""
         self[measurement.metric_name] = measurement
+
+    def update(self, other):
+        """Merge another `MeasurementSet` into this one.
+
+        Parameters
+        ---------
+        other : `MeasurementSet`
+            Another `MeasurementSet`. Measurements in ``other`` that do
+            exist in this set are added to this one. Measurements in
+            ``other`` replace measurements of the same metric in this one.
+        """
+        for _, measurement in other.items():
+            self.insert(measurement)
 
     @property
     def json(self):

--- a/python/lsst/verify/measurementset.py
+++ b/python/lsst/verify/measurementset.py
@@ -199,6 +199,31 @@ class MeasurementSet(JsonSerializationMixin):
         for _, measurement in other.items():
             self.insert(measurement)
 
+    def refresh_metrics(self, metric_set):
+        """Refresh `Measurement.metric` attributes in measurements contained
+        by this set.
+
+        Parameters
+        ----------
+        metric_set : `MetricSet`
+            Metrics from this set are inserted into corresponding
+            `Measurement`\ s contained in this `MeasurementSet`.
+
+        Notes
+        -----
+        This method is especially useful for inserting `Metric` instances into
+        `Measurement`\ s that weren't originally created with `Metric`
+        instances. By including a `Metric` in a `Measurement`, the serialized
+        units of a measurment are normalized to the metric's definition.
+
+        See also
+        --------
+        Job.reload_metrics_package
+        """
+        for metric_name, measurement in self.items():
+            if metric_name in metric_set:
+                measurement.metric = metric_set[metric_name]
+
     @property
     def json(self):
         """A `dict` that can be serialized as JSON."""

--- a/python/lsst/verify/metadata/__init__.py
+++ b/python/lsst/verify/metadata/__init__.py
@@ -1,0 +1,22 @@
+#
+# LSST Data Management System
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# See COPYRIGHT file at the top of the source tree.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <https://www.lsstcorp.org/LegalNotices/>.
+#

--- a/python/lsst/verify/metadata/eupsmanifest.py
+++ b/python/lsst/verify/metadata/eupsmanifest.py
@@ -1,0 +1,146 @@
+#
+# LSST Data Management System
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# See COPYRIGHT file at the top of the source tree.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <https://www.lsstcorp.org/LegalNotices/>.
+#
+"""API for parsing the manifest.txt file for EUPS packages found in lsstsw.
+"""
+
+from __future__ import print_function
+
+__all__ = ['Manifest']
+
+from collections import OrderedDict, namedtuple
+
+
+ManifestItem = namedtuple('ManifestItem',
+                          ['name', 'git_sha', 'version', 'dependencies'])
+
+
+class Manifest(object):
+    """Iterator over packages in lsstsw's manifest.txt dataset.
+
+    Parameters
+    ----------
+    manifest_stream : file handle
+        A file handle for `manifest.txt` (from `open`, for example).
+    """
+
+    def __init__(self, manifest_stream):
+        self._build_id = None
+        self._packages = OrderedDict()
+
+        self._parse_manifest_stream(manifest_stream)
+
+    def _parse_manifest_stream(self, manifest_stream):
+        for manifest_line in manifest_stream.readlines():
+            manifest_line = manifest_line.strip()
+            if manifest_line.startswith('#'):
+                continue
+            elif manifest_line.startswith('BUILD'):
+                self._build_id = manifest_line.split('=')[-1]
+                continue
+            parts = manifest_line.split()
+            package_name = parts[0]
+            git_commit = parts[1]
+            eups_version = parts[2]
+            if len(parts) == 4:
+                deps = parts[3].split(',')
+            else:
+                deps = list()
+
+            package = ManifestItem(
+                name=package_name,
+                git_sha=git_commit,
+                version=eups_version,
+                dependencies=deps)
+            self._packages[package_name] = package
+
+    def __iter__(self):
+        """Iterate over package names.
+
+        Yields
+        ------
+        name : `str`
+            Package name.
+        """
+        for package in self._packages:
+            yield package
+
+    def items(self):
+        """Iterate over packages.
+
+        Yields
+        ------
+        item : `tuple`
+            Tuple of ``(name, manifest_item)``. ``manifest_item`` is a
+            `ManifestItem` (namedtuple) type with fields:
+
+            - ``name``
+            - ``git_sha``
+            - ``version`` (EUPS version)
+            - ``dependencies`` (list of EUPS package names)
+        """
+        for item in self._packages.items():
+            yield item
+
+    def __len__(self):
+        """Count number of packages in the manifest (`int`)."""
+        return len(self._packages)
+
+    def __getitem__(self, package_name):
+        """Get a package item from the manifest by name.
+
+        Parameters
+        ----------
+        package_name : `str`
+            EUPS package name.
+
+        Returns
+        -------
+        item : `ManifestItem`
+            `ManifestItem` is a `namedtuple` type with fields:
+
+            - ``name``
+            - ``git_sha``
+            - ``version`` (EUPS version)
+            - ``dependencies`` (list of EUPS package names)
+        """
+        return self._packages[package_name]
+
+    def __contains__(self, package_name):
+        """Test if a package is in the manifest.
+
+        Parameters
+        ----------
+        package_name : `str`
+            EUPS package name.
+
+        Returns
+        -------
+        contained : `bool`
+            `True` if package is in the manifest.
+        """
+        return package_name in self._packages
+
+    @property
+    def build(self):
+        """Build number, bNNNN (`str`)."""
+        return self._build_id

--- a/python/lsst/verify/metadata/jenkinsci.py
+++ b/python/lsst/verify/metadata/jenkinsci.py
@@ -1,0 +1,81 @@
+#
+# LSST Data Management System
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# See COPYRIGHT file at the top of the source tree.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <https://www.lsstcorp.org/LegalNotices/>.
+#
+from __future__ import print_function
+
+__all__ = ['get_jenkins_env']
+
+import datetime
+import os
+
+
+def get_jenkins_env():
+    """Gather metadata entries from LSST DM Jenkins CI environment.
+
+    Returns
+    -------
+    prov : `dict`
+        Dictionary of metadata items obtained from the Jenkins CI
+        environment. Fields are:
+
+        - ``'date'``: ISO8601-formatted current datetime.
+        - ``'ci_id'``: Job ID in Jenkins CI.
+        - ``'ci_name'``: Job name in Jenkins CI.
+        - ``'ci_dataset'``: Name of the dataset being processed.
+        - ``'ci_label'``: Value of ``${label}`` environment variable in
+          Jenkins CI.
+        - ``'ci_url'``: URL to job page in Jenkins CI.
+        - ``'status'``: Job return status (always ``0``).
+
+    Examples
+    --------
+    This metadata is intended to be inserted into a job's metadata:
+
+    >>> from lsst.verify import Job
+    >>> job = Job()
+    >>> job.meta.update(get_jenkins_env())
+    """
+    utc = UTC()
+
+    return {
+        'date': datetime.datetime.now(utc).isoformat(),
+        'ci_id': os.getenv('BUILD_ID', 'unknown'),
+        'ci_name': os.getenv('PRODUCT', 'unknown'),
+        'ci_dataset': os.getenv('dataset', 'unknown'),
+        'ci_label': os.getenv('label', 'unknown'),
+        'ci_url': os.getenv('BUILD_URL', 'https://example.com'),
+        'status': 0,
+    }
+
+
+class UTC(datetime.tzinfo):
+    """UTC timezone."""
+    # http://stackoverflow.com/a/2331635
+
+    def utcoffset(self, dt):
+        return datetime.timedelta(0)
+
+    def tzname(self, dt):
+        return "UTC"
+
+    def dst(self, dt):
+        return datetime.timedelta(0)

--- a/python/lsst/verify/metadata/lsstsw.py
+++ b/python/lsst/verify/metadata/lsstsw.py
@@ -1,0 +1,152 @@
+#
+# LSST Data Management System
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# See COPYRIGHT file at the top of the source tree.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <https://www.lsstcorp.org/LegalNotices/>.
+#
+"""APIs for building software provenance from lsstsw."""
+
+from __future__ import print_function
+
+__all__ = ['LsstswRepos']
+
+from past.builtins import basestring
+
+import os
+
+import yaml
+try:
+    # GitPython is an optional dependency, not part of the LSST Stack.
+    import git
+except ImportError:
+    git = None
+
+
+class LsstswRepos(object):
+    """lsstsw package version information based on repos.yaml and
+    checked out Git repositories.
+
+    Parameters
+    ----------
+    dirname : `str`
+        Path of an ``lsstsw`` directory.
+    """
+    def __init__(self, dirname):
+        self._dirname = dirname
+        self._repos = self._load_repos_yaml()
+
+    def __contains__(self, package_name):
+        """Test if a package is present in `lsstsw`'s repos.yaml dataset.
+        """
+        return package_name in self._repos
+
+    def __len__(self):
+        return len(self._repos)
+
+    @property
+    def manifest_path(self):
+        """Path of the manifest.txt file."""
+        return os.path.join(self._dirname, 'build', 'manifest.txt')
+
+    def get_package_repo_path(self, package_name):
+        """Path to a EUPS package repository in lsstsw/build.
+
+        Parameters
+        ----------
+        package_name : `str`
+            Name of the EUPS package.
+
+        Returns
+        -------
+        path : `str`
+            Directory path of the package's Git repository in lsstsw/build.
+        """
+        return os.path.join(self._dirname, 'build', package_name)
+
+    def get_package_branch(self, package_name):
+        """Get the name of the checked-out branch of an EUPS package cloned in
+        lsstsw/build.
+
+        Parameters
+        ----------
+        package_name : `str`
+            Name of the EUPS package.
+
+        Returns
+        -------
+        branch : `str`
+            Name of the checked-out Git branch. If GitPython is not
+            installed, `None` is always returned instead.
+        """
+        if git is not None:
+            repo = git.Repo(self.get_package_repo_path(package_name))
+            return repo.active_branch.name
+        else:
+            return None
+
+    def get_package_commit_sha(self, package_name):
+        """Get the hex SHA of the checked-out commit of an EUPS package
+        cloned to lsstsw/build.
+
+        Parameters
+        ----------
+        package_name : `str`
+            Name of the EUPS package.
+
+        Returns
+        -------
+        commit : `str`
+            Hex SHA of the checkout-out Git commit. If GitPython is not
+            installed, `None` is always returned instead.
+        """
+        if git is not None:
+            repo = git.Repo(self.get_package_repo_path(package_name))
+            return repo.active_branch.commit.hexsha
+        else:
+            return None
+
+    def get_package_repo_url(self, package_name):
+        """URL of the package's Git repository.
+
+        This data is obtained from lsstsw/etc/repos.yaml.
+
+        Parameters
+        ----------
+        package_name : `str`
+            Name of the EUPS package.
+
+        Returns
+        -------
+        repo_url : `str`
+            Git origin URL of the package's Git repository.
+        """
+        s = self._repos[package_name]
+        if isinstance(s, basestring):
+            return s
+        else:
+            # For packages that have sub-documents, rather than the value
+            # as the URL. See repos.yaml for format documentation.
+            return s['url']
+
+    def _load_repos_yaml(self):
+        """Load lsstsw's repos.yaml."""
+        yaml_path = os.path.join(self._dirname, 'etc', 'repos.yaml')
+        with open(yaml_path) as f:
+            repos = yaml.safe_load(f)
+        return repos

--- a/python/lsst/verify/metricset.py
+++ b/python/lsst/verify/metricset.py
@@ -269,6 +269,28 @@ class MetricSet(JsonSerializationMixin):
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    def __iadd__(self, other):
+        """Merge another `MetricSet` into this one.
+
+        Parameters
+        ---------
+        other : `MetricSet`
+            Another `MetricSet`. Metrics in ``other`` that do exist in this
+            set are added to this one. Metrics in ``other`` replace metrics of
+            the same name in this one.
+
+        Returns
+        -------
+        self : `MetricSet`
+            This `MetricSet`.
+
+        Notes
+        -----
+        Equivalent to `update`.
+        """
+        self.update(other)
+        return self
+
     def insert(self, metric):
         """Insert a `Metric` into the set.
 
@@ -342,3 +364,16 @@ class MetricSet(JsonSerializationMixin):
             metrics = []
 
         return MetricSet(metrics)
+
+    def update(self, other):
+        """Merge another `MetricSet` into this one.
+
+        Parameters
+        ---------
+        other : `MetricSet`
+            Another `MetricSet`. Metrics in ``other`` that do exist in this
+            set are added to this one. Metrics in ``other`` replace metrics of
+            the same name in this one.
+        """
+        for _, metric in other.items():
+            self.insert(metric)

--- a/python/lsst/verify/specset.py
+++ b/python/lsst/verify/specset.py
@@ -622,6 +622,28 @@ class SpecificationSet(JsonSerializationMixin):
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    def __iadd__(self, other):
+        """Merge another `SpecificationSet` into this one.
+
+        Parameters
+        ---------
+        other : `SpecificationSet`
+            Another `SpecificationSet`. Specification in ``other`` that do
+            exist in this set are added to this one. Specification in ``other``
+            replace specifications of the same name in this one.
+
+        Returns
+        -------
+        self : `SpecificationSet`
+            This `SpecificationSet`.
+
+        Notes
+        -----
+        Equivalent to `update`.
+        """
+        self.update(other)
+        return self
+
     def items(self):
         """Iterate over name, specification pairs.
 
@@ -648,6 +670,19 @@ class SpecificationSet(JsonSerializationMixin):
         """
         key = spec.name
         self[key] = spec
+
+    def update(self, other):
+        """Merge another `SpecificationSet` into this one.
+
+        Parameters
+        ---------
+        other : `SpecificationSet`
+            Another `SpecificationSet`. Specification in ``other`` that do
+            exist in this set are added to this one. Specification in ``other``
+            replace specifications of the same name in this one.
+        """
+        for _, spec in other.items():
+            self.insert(spec)
 
     def resolve_document(self, spec_doc):
         """Resolve inherited properties in a specification document using

--- a/python/lsst/verify/squash.py
+++ b/python/lsst/verify/squash.py
@@ -1,0 +1,270 @@
+#
+# LSST Data Management System
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# See COPYRIGHT file at the top of the source tree.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <https://www.lsstcorp.org/LegalNotices/>.
+#
+"""SQUASH (https://squash.lsst.codes) client.
+
+Data objects, particularly Job, Metric, and Specification, use this client to
+upload and retrieve data from the SQUASH verification database.
+
+SQUASH will likely be replaced by a database served behind Data Management's
+webserv API. This client is considered a shim during construction.
+"""
+from __future__ import print_function
+
+__all__ = ['get', 'post', 'get_endpoint_url', 'reset_endpoint_cache',
+           'get_default_timeout', 'get_default_api_version',
+           'make_accept_header']
+
+import json
+
+import requests
+
+import lsst.log
+
+# Version of the SQUASH API this client is compatible with
+_API_VERSION = '2.0'
+
+# Default HTTP timeout (seconds) for all SQUASH client requests.
+_TIMEOUT = 30.0
+
+# URLs for SQUASH endpoints, cached by `get_endpoint_url()`.
+_ENDPOINT_URLS = None
+
+
+def get_endpoint_url(api_url, api_endpoint, **kwargs):
+    """Lookup SQUASH endpoint URL.
+
+    Parameters
+    ----------
+    api_url : `str`
+        Root URL of the SQUASH API. For example,
+        ``'https://squash.lsst.codes/dashboard/api/'``.
+    api_endpoint : `str`
+        Name of the SQUASH API endpoint. For example, ``'jobs'``.
+    **kwargs : optional
+        Additional keyword arguments passed to `get`.
+
+    Returns
+    -------
+    endpoint_url : `str`
+        Full SQUASH endpoint URL.
+
+    Notes
+    -----
+    Endpoints are discovered from the SQUASH API itself. The SQUASH API is
+    queried on the first call to `get_endpoint_url`. Subsequent calls use
+    cached results for all endpoints. This cache can be reset with the
+    `reset_endpoint_cache` function.
+    """
+    global _ENDPOINT_URLS
+
+    if _ENDPOINT_URLS is None:
+        r = get(api_url, **kwargs)
+        _ENDPOINT_URLS = r.json()
+
+    return _ENDPOINT_URLS[api_endpoint]
+
+
+def reset_endpoint_cache():
+    """Reset the cache used by `get_endpoint_url`.
+    """
+    global _ENDPOINT_URLS
+    _ENDPOINT_URLS = None
+
+
+def get_default_timeout():
+    """Get the default HTTP client timeout setting.
+
+    Returns
+    -------
+    timeout : `float`
+        Default timeout setting, in seconds.
+    """
+    global _TIMEOUT
+    return _TIMEOUT
+
+
+def get_default_api_version():
+    """Get the default SQUASH API versioned used by the lsst.verify.squash
+    client functions.
+
+    Returns
+    -------
+    version : `str`
+        API version. For example, ``'2.0'``.
+    """
+    global _API_VERSION
+    return _API_VERSION
+
+
+def make_accept_header(version=None):
+    """Make the ``Accept`` HTTP header for versioned SQUASH API requests.
+
+    Parameters
+    ----------
+    version : `str`, optional
+        Semantic API version, such as ``'1.0'``. By default, the API version
+        this client is designed for is used (`get_default_api_version`).
+
+    Returns
+    -------
+    accept_header : `str`
+        The ``Accept`` header value.
+
+    Examples
+    --------
+    >>> make_accept_header()
+    'application/json; version=2.0'
+    """
+    if version is None:
+        version = get_default_api_version()
+    template = 'application/json; version={0}'
+    return template.format(version)
+
+
+def post(api_url, api_endpoint, json_doc=None,
+         api_user=None, api_password=None, timeout=None, version=None):
+    """POST a JSON document to SQUASH.
+
+    Parameters
+    ----------
+    api_url : `str`
+        Root URL of the SQUASH API. For example,
+        ``'https://squash.lsst.codes/api'``.
+    api_endpoint : `str`
+        Name of the API endpoint to post to.
+    json_doc : `dict`
+        A JSON-serializable object.
+    api_user : `str`
+        API username.
+    api_password : `str`
+        API password.
+    timeout : `float`, optional
+        Request timeout. The value of `get_default_timeout` is used by default.
+    version : `str`, optional
+        API version. The value of `get_default_api_version` is used by default.
+
+    Raises
+    ------
+    requests.exceptions.RequestException
+       Raised if the HTTP request fails.
+
+    Returns
+    -------
+    response : `requests.Response`
+        Response object. Obtain JSON content with ``response.json()``.
+    """
+    log = lsst.log.Log.getLogger('verify.squash.post')
+
+    api_endpoint_url = get_endpoint_url(api_url, api_endpoint)
+
+    headers = {
+        'Accept': make_accept_header(version)
+    }
+
+    try:
+        # Disable redirect following for POST as requests will turn a POST into
+        # a GET when following a redirect. http://ls.st/pbx
+        r = requests.post(api_endpoint_url,
+                          auth=(api_user, api_password),
+                          json=json_doc,
+                          allow_redirects=False,
+                          headers=headers,
+                          timeout=timeout or get_default_timeout())
+        log.info('POST {0} status: {1}'.format(api_endpoint_url,
+                                               r.status_code))
+        r.raise_for_status()
+
+        # be pedantic about return status. requests#status_code will not error
+        # on 3xx codes
+        if r.status_code != 201:
+            message = 'Expected status=201. Got status={0}. {1}'.format(
+                r.status_code, r.reason)
+            raise requests.exceptions.RequestException(message)
+    except requests.exceptions.RequestException as e:
+        log.error(str(e))
+        log.error(json.dumps(json_doc))
+        raise e
+
+    return r
+
+
+def get(api_url, api_endpoint=None,
+        api_user=None, api_password=None, timeout=None, version=None):
+    """GET request to the SQUASH API.
+
+    Parameters
+    ----------
+    api_url : `str`
+        Root URL of the SQUASH API. For example,
+        ``'https://squash.lsst.codes/api'``.
+    api_endpoint : `str`, optional
+        Name of the API endpoint to post to. The ``api_url`` is requested if
+        unset.
+    api_user : `str`, optional
+        API username.
+    api_password : `str`, optional
+        API password.
+    timeout : `float`, optional
+        Request timeout. The value of `get_default_timeout` is used by default.
+    version : `str`, optional
+        API version. The value of `get_default_api_version` is used by default.
+
+    Raises
+    ------
+    requests.exceptions.RequestException
+       Raised if the HTTP request fails.
+
+    Returns
+    -------
+    response : `requests.Response`
+        Response object. Obtain JSON content with ``response.json()``.
+    """
+    log = lsst.log.Log.getLogger('verify.squash.get')
+
+    if api_user is not None and api_password is not None:
+        auth = (api_user, api_password)
+    else:
+        auth = None
+
+    if api_endpoint is not None:
+        api_endpoint_url = get_endpoint_url(api_url, api_endpoint)
+    else:
+        api_endpoint_url = api_url
+
+    headers = {
+        'Accept': make_accept_header(version)
+    }
+
+    try:
+        r = requests.get(api_endpoint_url,
+                         auth=auth,
+                         headers=headers,
+                         timeout=timeout or get_default_timeout())
+        log.info('GET {0} status: {1}'.format(api_endpoint_url,
+                                              r.status_code))
+        r.raise_for_status()
+    except requests.exceptions.RequestException as e:
+        log.error(str(e))
+        raise e
+
+    return r

--- a/tests/data/lsstsw/build/manifest.txt
+++ b/tests/data/lsstsw/build/manifest.txt
@@ -1,0 +1,134 @@
+# product                 SHA1                                      Version                       
+BUILD=b1988
+cfitsio                   b56ecf282e296255677bc23bc742639d726270fa  3360.lsst4                               
+throughputs               7632edaa9e93d06576e34a065ea4622de8cc48d0  master-g7632edaa9e                       
+eigen                     70497dd3005d70ff8b3e7e665e4ea9ed04ebb1a9  3.2.5.lsst1                              
+antlr                     d81cf0cd80e0ed4ab73314e1062ce2396bbd0a0e  2.7.7.lsst1                              
+mariadbclient             2ac29f107c13408dea0dc8003012259eb4b269ed  10.1.11.lsst2                            
+pyephem                   2fa459bf78ce024ea022dfdeba525a395984f205  3.7.5.1.lsst1                            
+lua                       419130092c6420d68845b6f9d2c9873814523142  5.1.4.lsst1                              
+wcslib                    373bd44add489cc091272d3393ae8d9857bcd34d  5.13.lsst1                               cfitsio
+xpa                       eb35b1105c2a44557af660104f2807e2b28255dd  2.1.15.lsst3                             
+sims_skybrightness_data   1cb9a9a3832d672ce092318be8601624d1718601  master-g1cb9a9a383                       
+testdata_subaru           2098685e18f8505f499d17d3c4921cb918f8623d  master-g2098685e18                       
+python_d2to1              be638fbf6609db5ac7ab904d3c76eaaa1f55df3b  0.2.12.lsst1                             
+mpich                     aeebd6bccdaf6fa848d6a3ccd7be8c882a3038ea  3.2                                      
+sims_sed_library          56a7d82e67353ae13f8551edf93f6f98c6e8827b  2016.01.26                               
+freetds                   158005830bde34bde7db91bbf1b812d67012f9e6  0.91.112.lsst2                           
+stsci_distutils           4bba6935c89f769e59cec6780a68ba8509fccfb0  0.3.7.lsst1                              python_d2to1
+apr                       39b3212aa46217e4f485b02496381907da8b8d7a  1.5.2                                    
+minuit2                   dae2fb72f087c8d6dd1c4e0cfe8a828920f3412e  5.34.14                                  
+python                    259ae7060d5430926998615a42cf4b4c117a449e  0.0.3                                    
+swig                      ccf66d07ee20460f0eb3c396d8f04e5d5e249ee3  3.0.2.lsst1                              
+mpi                       6f350834c9ad5859cb069326232a27cdc6cfe17d  0.0.1+1                                  mpich
+xrootd                    5f6a5d06db488e44bee6fe1104d4d9e4d5357c70  2016_02                                  
+astropy                   47e80e26de26053521c607df82a3a4512572362b  0.0.1.lsst1-2-g47e80e2                   python
+libevent                  ab04e34f14107106ac2101d52a84488f0939590f  2.0.16.lsst2                             
+pymssql                   02c450b095cda9e17f5425d9d05c4483169d95fc  2.1.1+3                                  python,freetds
+mariadb                   fe7e7b24e7db405979d8827a650cdf4e8a22ec26  10.1.11.lsst2                            
+pyyaml                    cb5cda908acb5a4fe493b618f9519bb26f7b1275  3.11.lsst1                               python
+doxygen                   323f9952c1e0db0fb8ebb0317f69d4019bd38d88  1.8.5.lsst1                              
+boost                     41d5ba29a6bdc6a68f4b6a8dbf82aa0176eee3f4  1.60                                     python
+sims_data                 dac76d2d31a18efd420080cf729efcfc59b66910  10.1                                     
+fftw                      30c2cc419e7200314efbef8d0c432ac11e9d41be  3.3.4.lsst2                              
+requests                  83cdaf189ad5e7f0f7805ba3104f4cf0c748d363  2016_01.0                                python
+mysqlpython               120147b0169a7fbf5a32690ca53bc846311b719a  1.2.3.lsst2                              python,mariadbclient
+activemqcpp               44a13ddf9c71f92da39be477522e24f994e84c92  3.9.0.lsst2+3                            apr,doxygen
+gsl                       a5b7ea77e0be9d4f91e1a71ec7b08db0bdbf6e58  1.16.lsst3                               
+pykg_config               c4dd3b426d8c89d1abccbd64ed5e3e3ea4209f2f  1.2.0+5                                  python
+apr_util                  45d74ccc249484be4fdba93fe2f66aafb5869335  1.5.4                                    apr
+python_psutil             11e66a19cedecba67caa0c08675b630e3806927a  4.1.0                                    python
+mysqlproxy                eea091aa8b895efbb59d5c041f9b4c67b045b5fa  0.8.5+12                                 libevent,lua,mariadb
+mpi4py                    7bd49cfdef82e5b48667c3c94f14ed315b9673a2  1.3.1.lsst2                              python,mpi
+scisql                    452e5282e775b5a00153c8b6462da7a8ca2009ad  0.3.5+12                                 mariadb,mysqlpython,python
+flask                     cdb2e41bf97dccb0a2b57c6368b27d3d5cc27460  0.10.1-1-gcdb2e41                        python
+scons                     159b9a213dee398d4d353cc1fcca05d77047a3f8  2.3.5                                    python
+sconsUtils                e052bd8966c0e773d00001850c3f1bcabaa65d4d  2016_01.0-8-ge052bd8                     scons,doxygen
+numpy                     4e70653b6b68a9a5d163932472b6fdf48b708a63  0.0.2                                    python
+astrometry_net            ae735ff9e7de1768877c77075049f1b66ced0300  0.50.lsst2-1-gae735ff                    cfitsio,wcslib,gsl,numpy
+sncosmo                   f0bda14b689df4450dc1bf1abfca3e639afb1a11  1.2.0-1-gf0bda14                         python,numpy,astropy
+afwdata                   5f41616c3e012c71aab395c67e5bba3e1ed9ee34  2016_01.0+6                              sconsUtils
+palpy                     733f88b7b6af36261a0833ad7c04c076d872d90b  1.7.0.lsst1-1-g733f88b                   numpy,python
+pyfits                    40c72f9bf25b2240d7b1b6b5b6547a451ab78a28  3.4.0+3                                  numpy,python_d2to1,stsci_distutils
+psfex                     eb1eb6777f0e263a159a05c00c0b66a739f86688  2016_01.0+5                              gsl,sconsUtils,fftw
+tmv                       0ea1a31cb532e33dbfa76ff5afcafc4636d7d759  0.72.lsst4                               scons
+healpy                    d4cac0b74d707cc97b912fa01d6d2c0d9c9eb947  1.8.1.lsst2                              python,numpy,pykg_config,cfitsio,pyfits
+lsst                      80ea1a1ae607f5b7fdf5d1866ee50de7b399be0a  2016_01.0-10-g80ea1a1                    sconsUtils
+geom                      e36792e6e9d9e1dba9c850006c7d1175100e0ab0  10.0+56                                  sconsUtils
+log4cxx                   e820ae31346b4b1cf8c592e94d1ee6498213aa9b  0.10.0.lsst6+1                           apr,apr_util
+sqlalchemy                af5a1cb44943d13994e80302426225e7069d8ed6  1.0.8.lsst3                              python
+protobuf                  dbe97ed4c2d9363d541405f325c2304ebe90a7c5  2015_11.0                                python
+matplotlib                e49e23a949f741e58439684a965c869dea134c8a  0.0.2                                    python,numpy
+base                      e90c490d2b20c66d4a92d0bc2f384a7310f96cbb  2.2016.10-2-ge90c490+1                   boost,sconsUtils,swig,doxygen
+sphgeom                   e1016e6e5ab0cbdf3cb5ac22b3da22f5edfa3789  2016_04                                  base,sconsUtils,swig,doxygen
+ndarray                   4d828c719cd8ff4e2d50a60d03cb259304108b8d  2016_01.0-1-g4d828c7+1                   boost,python,numpy,eigen,base,swig,fftw
+partition                 d312b5f730ab4b6ddb8ee09d90d855270118f00b  2016_04                                  boost,sconsUtils
+esutil                    f7abc5adc9104c37a88dd7aa1d950873f1a8193a  0.5.3                                    python,numpy
+scipy                     aedd72728b314c7adcb2bc108d85b02a75efc322  master-gaedd72728b                       python,numpy
+astrometry_net_data       eaffc02df2119a5f17862630057df8974f07ca23  10.0+69                                  sconsUtils
+dax_webservcommon         29f49bca873b8a563bcf5ea660731fd3007ecbe4  2016_01.0-1-g29f49bc+1                   python,scons,sconsUtils
+galsim                    7bce59124626086b2660e4e9f3a95c82f8f0017b  1.3.2.lsst1-1-g7bce591                   numpy,pyfits,boost,fftw,tmv,astropy
+pex_exceptions            fde6942edd7cc692bd0de09b2eb28bb9a356a296  2016_01.0-1-gfde6942+1                   base,boost,swig
+log                       03cea0f729b8a1f793048251aaca29e1af206e0a  2016_01.0-4-g03cea0f+3                   boost,log4cxx,base,sconsUtils
+lmfit                     0239b733156600f9ce4602ec7a1a266ee14856b0  0.9.3                                    python,numpy,scipy
+db                        079dcf89e86b9accffe449c5ffcec5ae7daf039a  2016_02+5                                log,python,mariadbclient,mysqlpython,sconsUtils,sqlalchemy
+dax_dbserv                172dcd16e0ec79efbd6a331206102c2ffcce1e22  2016_03                                  dax_webservcommon,db,flask,log,mysqlpython,python,scons,sconsUtils,sqlalchemy
+dax_metaserv              5234aa38b2a2fb46986bf20fcad50dd69796eed6  2016_03                                  dax_webservcommon,db,flask,mysqlpython,python,scons,sconsUtils,sqlalchemy
+utils                     f0ccc9b86f3d2f3682c4f93ec931d678d7e847a3  2016_01.0-5-gf0ccc9b                     base,pex_exceptions,boost,numpy,python_psutil
+sims_maps                 f92a6bcd0e1afefc5812929bf395ef935d05fef7  master-gf92a6bcd0e                       python,utils
+daf_base                  54642da966602dae9bab61ed2cc572ebd4dfff6a  2016_01.0-2-g54642da                     utils,pex_exceptions,numpy
+qserv                     f613ca9cbe81bb4197c552c72f6cdf11cbde0ac5  2016_04-5-gf613ca9                       antlr,boost,db,doxygen,flask,log,log4cxx,lua,mariadb,mysqlproxy,mysqlpython,partition,protobuf,python,requests,scisql,scons,sphgeom,sqlalchemy,swig,xrootd
+sims_utils                ce6506fe67f3c80dda5287ba087c61dd6e5a4356  2.1.2-13-gce6506f                        utils,python,palpy,sims_data,healpy
+qserv_testdata            f23ac01765543b002d73da6d5e52f800bcb04273  2016_03                                  python,pyyaml,qserv,scons,sconsUtils
+pex_policy                9f41d6ce7b767b36b610cd19fd8a4b1ce7780368  2016_01.0-1-g9f41d6c+1                   daf_base,utils
+pex_logging               1a9be9b21c7368a697f2e52b7d91b0cb5aae28e0  2016_01.0-3-g1a9be9b                     pex_exceptions,daf_base,utils
+ctrl_events               fa44e16f56ac3607c145cc4acf0a2f7645d77aa3  2016_01.0-4-gfa44e16                     boost,activemqcpp,utils,base,daf_base,pex_exceptions,log4cxx,log,swig,doxygen
+pex_config                6fbf65447270f8a73482d77cb2f05195c92d6946  2016_01.0-1-g6fbf654+1                   daf_base,pex_policy,numpy,utils
+sims_photUtils            93241d18c1ba495f8d87cf00a87e51084a28a0db  2.1.2-8-g93241d1                         utils,sims_sed_library,sims_maps,sims_utils,python,throughputs,pyfits,astropy
+qserv_distrib             35cc638215f828d7db194adb2cdc790c6b308e37  1.0.0+539                                qserv,partition,qserv_testdata
+daf_persistence           a3a0b0789f8cb8d1137b5b59109b3720164f2464  2016_01.0-9-ga3a0b07+1                   mariadbclient,pex_logging,pex_policy,pyfits,pyyaml
+cat                       7ce2ae36d5403f6c063e5ebce53d9554aa5e81cd  2016_01.0-3-g7ce2ae3+22                  python,mariadbclient,mysqlpython,db,log,boost,pex_policy,daf_base,daf_persistence,utils,pex_exceptions
+sims_skybrightness        1683d97c4a0f03104b093e7b3e448f209e3b1093  master-g1683d97c4a                       base,numpy,matplotlib,pyephem,sims_utils,sims_photUtils,utils,throughputs,sims_skybrightness_data,healpy
+ctrl_provenance           ef242a4068eca3c6131760869447c075c3993753  2016_01.0+32                             cat,pex_policy,pex_logging
+sims_catalogs_generation  dcfd1fdd27694ad803f20a694d01130dd5fe0a9f  2.1.2-6-gdcfd1fd+13                      daf_persistence,mysqlpython,pymssql,python,sims_utils,sqlalchemy,utils
+afw                       fc355a99abe3425003b0e5fbe1e13a39644b1e95  2.2016.10-22-gfc355a9                    daf_base,daf_persistence,pex_config,ndarray,cfitsio,wcslib,numpy,minuit2,eigen,gsl,fftw,utils,astropy,pyfits,matplotlib,afwdata
+sims_catalogs_measures    a4c308f42782e67a2d885cd7bf65e7aa457ecf83  2.1.2-3-ga4c308f+30                      utils,python,sims_utils,sims_catalogs_generation
+sims_coordUtils           3ce4a30483889d98566a13398908421b4bb4ddbc  2.1.2-1-g3ce4a30+58                      sims_utils,utils,base,python,throughputs,palpy,pyfits,afw
+ctrl_orca                 4f54dabfedeb686ca6cfb8a4af81a857a4f02528  2016_01.0+34                             cat,utils,pex_policy,daf_persistence,ctrl_events,ctrl_provenance,log
+display_ds9               ef1a7a9b7e0ac6729ed3cc4f4df9282ebc8385cd  2015_10.0+75                             afw,xpa
+ctrl_execute              4ff36707c8deb86ffe0eda9283342fb4bd0d9e58  2016_01.0+34                             ctrl_orca,pex_config,utils
+ctrl_platform_lsst        e2704ccbb1a39dc2d4f3c51eb969ee7f71891d10  11.0+81                                  ctrl_execute
+skypix                    1157bf09aee6dda8cdefede4395220da4b46d0fe  10.0+380                                 utils,pex_policy,geom,afw
+shapelet                  46e3358dfa68225444a56b643ad6167d09d18012  2016_01.0-5-g46e3358                     afw,numpy,scons,sconsUtils
+skymap                    101aa9ada597bd5600579e5aa71bf03042454f4e  2016_01.0-2-g101aa9a+1                   numpy,afw
+daf_butlerUtils           74d5a09cae3a657e2284a237479dcd4226c1d34c  2016_01.0-6-g74d5a09                     daf_base,pex_logging,pex_policy,daf_persistence,afw,skypix,pyfits,utils
+obs_test                  afa6dd00e81def07eb35b7a172e0f69d6aa020fa  2016_01.0-3-gafa6dd0+1                   afw,daf_base,daf_butlerUtils,pex_config,pex_policy,numpy,skypix,utils
+ctrl_platform_gordon      950df44ac2f0417f070990fb41d017233a5ad47d  11.0+81                                  ctrl_execute
+pipe_base                 bdeabf26f22d45bc587e3792a7e3b60e4f121c32  2016_01.0-9-gbdeabf2                     daf_persistence,pex_logging,pex_config,utils,afw,obs_test
+ctrl_pool                 faf42d3ee287ee901ea9a019807066b7df0c8515  master-gfaf42d3ee2                       daf_persistence,pipe_base,mpi4py
+coadd_utils               dbbfd04a8a97292b4bcf83e594ac03d230871e47  2016_01.0-2-gdbbfd04+19                  afw,numpy,pex_config,pipe_base,scons,sconsUtils,utils,afwdata
+coadd_chisquared          f871d2e19cb11ad3cdaabc3f5ffe5565a9ca5dd2  2016_01.0-1-gf871d2e+19                  coadd_utils,numpy,scons,sconsUtils,afwdata
+meas_base                 9b5ae8a384a3aa9768c8793b3eedc59d8b633c11  2016_01.0-25-g9b5ae8a                    afw,coadd_utils,daf_base,geom,numpy,pex_config,pipe_base,scons,sconsUtils
+meas_extensions_simpleShape c06b201c33381ec77594692f2ccf2a9bfc879503  master-gc06b201c33                       scons,sconsUtils,base,numpy,afw,meas_base,utils,pex_config,pex_exceptions
+meas_algorithms           0b881ef450e174eb9fc7fdd9ef7c59e0c30ff139  2016_01.0-16-g0b881ef                    daf_base,daf_persistence,afw,meas_base,minuit2,numpy,pex_config,pex_exceptions,pex_logging,pex_policy,pipe_base,scons,sconsUtils,utils
+ip_isr                    6f9b1d7b622a5370cfb94d45b890745d8d2fd59a  2016_01.0-14-g6f9b1d7                    meas_algorithms,numpy,pipe_base,scons,sconsUtils
+meas_extensions_shapeHSM  84a11d9992d58cfaa86f02f18bef9b8618f78e2e  7.1.1.0-13-g84a11d9                      meas_base,meas_algorithms,galsim,afw,daf_base,numpy,pex_exceptions,pex_logging,sconsUtils,utils
+meas_deblender            98803489591cb47d8fa0a4a44824cee7a4af03b4  2016_01.0-6-g9880348                     afw,meas_algorithms,numpy,scons,sconsUtils,utils,matplotlib
+ip_diffim                 378d0f7693e107f0de236e595cdd0e6d927dbac5  2016_01.0-13-g378d0f7                    afw,daf_base,daf_persistence,meas_algorithms,meas_base,meas_deblender,minuit2,numpy,pex_config,pex_logging,pex_policy,pipe_base,utils,lmfit,afwdata,matplotlib
+meas_extensions_psfex     4f7ae9c901eac3bef8c58ffcf2bfdc37ebe211f7  2016_01.0-9-g4f7ae9c                     afw,boost,daf_base,fftw,meas_algorithms,meas_base,numpy,psfex,scons,sconsUtils,swig,utils
+meas_astrom               c94ecbddc6f265aae2319a9317c38cfb644979b5  2016_01.0-11-gc94ecbd                    afw,meas_algorithms,pex_logging,pex_config,pipe_base,utils,wcslib,astrometry_net,numpy,matplotlib
+pipe_tasks                c25bc5466983c4c7a8190491b9ff507e7f45c5eb  2016_01.0-46-gc25bc54                    pipe_base,pex_config,utils,esutil,afw,meas_base,meas_algorithms,meas_astrom,meas_deblender,astrometry_net_data,ip_isr,ip_diffim,coadd_utils,coadd_chisquared,skymap,geom,obs_test,matplotlib
+obs_sdss                  1a6faba4491ff9142ac44dbbc7bdc05f416947b4  2016_01.0-8-g1a6faba                     pex_policy,daf_butlerUtils,afw,meas_algorithms,meas_astrom,mysqlpython,pipe_tasks,utils
+pipe_drivers              5cd3f853bf82541fdeebef6947f01626ce4e29df  master-g5cd3f853bf                       ctrl_pool,afw,pex_exceptions,geom,pex_config,pipe_base,pipe_tasks
+obs_lsstSim               85d3ac29298111a98e18457fcf8de8851b5fecf9  2016_01.0-19-g85d3ac2                    daf_base,pex_policy,afw,daf_persistence,daf_butlerUtils,meas_algorithms,ip_isr,pipe_tasks,mysqlpython,utils
+sims_maf                  0014a0384982ea75d7a3d000df8d89bb8dc8089b  2.1.3-39-g0014a03                        base,numpy,matplotlib,pyephem,palpy,healpy,sims_utils,sims_catalogs_generation,sims_photUtils,sims_coordUtils,sims_maps,obs_lsstSim
+datarel                   63a66a4a48e71a50ac8b56eac5ee0d1a6c2347a3  2016_01.0+58                             ctrl_orca,pipe_tasks,utils,obs_lsstSim,astrometry_net_data,matplotlib,cat,scisql
+sims_catUtils             1235fe2a75735d6f4603e2ad53e329b554b3ea51  2.1.2-13-g1235fe2                        utils,sims_utils,sims_catalogs_measures,sims_catalogs_generation,sims_coordUtils,sims_photUtils,sims_data,palpy,python,pymssql,daf_persistence,sncosmo,astropy,obs_lsstSim
+dax_imgserv               d86b19161f2a750db036c7e71a966e7fbc440e17  2016_01.0+2                              afw,base,boost,cat,daf_base,db,doxygen,flask,log,mysqlpython,obs_sdss,scons,sconsUtils,skymap,sqlalchemy
+meas_modelfit             e64899d1e14cda2781020a00dfd45797132a691a  2016_01.0-11-ge64899d                    afw,meas_algorithms,meas_base,numpy,pipe_tasks,scons,sconsUtils,shapelet,matplotlib
+obs_subaru                439fc5cec89463ae23e794fcbbdbd34acd602ef4  5.0.0.1-92-g439fc5c                      daf_persistence,daf_butlerUtils,skypix,pipe_tasks,meas_astrom,pyfits,sconsUtils,meas_modelfit,meas_extensions_psfex,meas_extensions_shapeHSM,testdata_subaru
+sims_GalSimInterface      e20c88b1329041df095aba9af3608c8e1440a8be  2.1.2-8-ge20c88b                         galsim,astropy,meas_astrom,afw,sims_utils,sims_coordUtils,sims_catalogs_generation,sims_catalogs_measures,sims_catUtils,obs_lsstSim
+dax_webserv               ac1ea996b3a488ded2cd4d53eaca6bb83d116fa7  2016_03                                  db,flask,dax_dbserv,dax_imgserv,dax_metaserv,mysqlpython
+lsst_apps                 d7afef2d9a291b490dfb6cd37680acd420918619  2016_01.0-1-gd7afef2                     meas_deblender,meas_modelfit,pipe_tasks,obs_lsstSim,obs_sdss,obs_test,meas_extensions_simpleShape,display_ds9,meas_extensions_psfex
+lsst_distrib              4a80fc89e6f643cb80287bb08529c22786be0a0a  2016_01.0-3-g4a80fc8                     lsst,lsst_apps,ctrl_execute,ctrl_platform_gordon,ctrl_platform_lsst,datarel,obs_subaru,meas_extensions_shapeHSM,pipe_drivers
+lsst_sims                 a3712cd25b4a32be0e6543c6c5f39969ca98661f  master-ga3712cd25b+54                    sims_maf,sims_GalSimInterface,sncosmo,sims_catUtils,sims_catalogs_generation,sims_catalogs_measures,sims_sed_library,sims_maps,sims_skybrightness

--- a/tests/data/lsstsw/etc/repos.yaml
+++ b/tests/data/lsstsw/etc/repos.yaml
@@ -1,0 +1,271 @@
+#
+# repos.yaml
+# ===
+#
+# Index of source repo locations for rebuild / lsst_build to clone from.
+#
+#
+# format of this file
+# ---
+#
+# It is in [YAML](http://yaml.org/) format with a single top level
+# dict/hash/map.  Each keypair specifies a source repo and a specification of
+# how it may be cloned.  Key names must conform to the EUPS product name of the
+# source package.  Values may be either a URL (string) or a dict/hash/map with
+# a `url` key and *at least* one `ref` or `lfs`.  The `ref` key generally
+# should be used only if a ref /other than/ `master` is desired.  The `lfs`
+# key is used to identicate that the repo is using git-lfs.
+#
+# * `url`: string - URL of git repo
+# * `ref`: string - ref (branch | tag) to use by default
+# * `lfs`: boolean - `true` (all lowercase) is the only supported value
+#
+# examples
+# ---
+#
+# ### string spec
+#
+#   afw: https://github.com/lsst/afw.git
+#
+# ### dict/hash/map spec
+#
+#        + whitespace or comments only after the colon
+#        |
+#        v
+#   afw:
+#     url: https://github.com/lsst/afw.git
+#     ref: my-magic-branch
+#
+#   ^
+#   |
+#   +--  2 space indent declaring a nested dict/hash/map
+#
+#   afwdata:
+#     url: https://github.com/lsst/afwdata.git
+#     lfs: true
+#
+---
+lsst_thirdparty: https://github.com/lsst/lsst_thirdparty.git
+lsst_apps: https://github.com/lsst/lsst_apps.git
+twisted: https://github.com/lsst/twisted.git
+throughputs: https://github.com/lsst/throughputs.git
+sims_utils: https://github.com/lsst/sims_utils.git
+sims_catalogs_measures: https://github.com/lsst/sims_catalogs_measures.git
+scisql: https://github.com/lsst/scisql.git
+pex_logging: https://github.com/lsst/pex_logging.git
+gcc: https://github.com/lsst/gcc.git
+luasocket: https://github.com/lsst/luasocket.git
+cfitsio: https://github.com/lsst/cfitsio.git
+lua: https://github.com/lsst/lua.git
+lsst_distrib: https://github.com/lsst/lsst_distrib.git
+ctrl_platform_lsst: https://github.com/lsst/ctrl_platform_lsst.git
+pex_config: https://github.com/lsst/pex_config.git
+lsstDoxygen: https://github.com/lsst/lsstDoxygen.git
+mysqlpython: https://github.com/lsst/mysqlpython.git
+python_mysqlclient: https://github.com/lsst/python_mysqlclient.git
+mysqlproxy: https://github.com/lsst/mysqlproxy.git
+sconsUtils: https://github.com/lsst/sconsUtils.git
+afw: https://github.com/lsst/afw.git
+meas_base: https://github.com/lsst/meas_base.git
+xrootd:
+  url: https://github.com/lsst/xrootd.git
+  ref: lsst-dev
+apr_util: https://github.com/lsst/apr_util.git
+daf_persistence: https://github.com/lsst/daf_persistence.git
+obs_lsstSim: https://github.com/lsst/obs_lsstSim.git
+log: https://github.com/lsst/log.git
+base: https://github.com/lsst/base.git
+scons: https://github.com/lsst/scons.git
+wcslib: https://github.com/lsst/wcslib.git
+log4cxx: https://github.com/lsst/log4cxx.git
+pymssql: https://github.com/lsst/pymssql.git
+apr: https://github.com/lsst/apr.git
+coadd_chisquared: https://github.com/lsst/coadd_chisquared.git
+pex_exceptions: https://github.com/lsst/pex_exceptions.git
+pyfits: https://github.com/lsst/pyfits.git
+coadd_utils: https://github.com/lsst/coadd_utils.git
+expat: https://github.com/lsst/expat.git
+zopeinterface: https://github.com/lsst/zopeinterface.git
+libevent: https://github.com/lsst/libevent.git
+lsst_sims: https://github.com/lsst/lsst_sims.git
+numpy: https://github.com/lsst/numpy.git
+scipy: https://github.com/lsst/scipy.git
+lmfit: https://github.com/lsst/lmfit.git
+esutil: https://github.com/lsst/esutil.git
+meas_deblender: https://github.com/lsst/meas_deblender.git
+gsl: https://github.com/lsst/gsl.git
+sims_maf: https://github.com/lsst/sims_maf.git
+sims_skybrightness: https://github.com/lsst/sims_skybrightness.git
+sims_skybrightness_data: https://github.com/lsst/sims_skybrightness_data.git
+lsst: https://github.com/lsst/lsst.git
+boost: https://github.com/lsst/boost.git
+sims_sed_library:
+    url: https://github.com/lsst/sims_sed_library.git
+    lfs: true
+zookeeper: https://github.com/lsst/zookeeper.git
+obs_test: https://github.com/lsst/obs_test.git
+ndarray: https://github.com/lsst/ndarray.git
+xpa: https://github.com/lsst/xpa.git
+ctrl_events: https://github.com/lsst/ctrl_events.git
+astrometry_net_data: https://github.com/lsst/astrometry_net_data.git
+db: https://github.com/lsst/db.git
+ctrl_platform_gordon: https://github.com/lsst/ctrl_platform_gordon.git
+pipe_base: https://github.com/lsst/pipe_base.git
+qserv_distrib: https://github.com/lsst/qserv_distrib.git
+daf_base: https://github.com/lsst/daf_base.git
+python: https://github.com/lsst/python.git
+freetds: https://github.com/lsst/freetds.git
+skymap: https://github.com/lsst/skymap.git
+doxygen: https://github.com/lsst/doxygen.git
+mariadb: https://github.com/lsst/mariadb.git
+mariadbclient: https://github.com/lsst/mariadbclient.git
+mysql: https://github.com/lsst/mysql.git
+ctrl_orca: https://github.com/lsst/ctrl_orca.git
+geom: https://github.com/lsst/geom.git
+sphgeom: https://github.com/lsst/sphgeom.git
+qserv: https://github.com/lsst/qserv.git
+palpy: https://github.com/lsst/palpy.git
+luaexpat: https://github.com/lsst/luaexpat.git
+cat: https://github.com/lsst/cat.git
+ip_isr: https://github.com/lsst/ip_isr.git
+pex_policy: https://github.com/lsst/pex_policy.git
+matplotlib: https://github.com/lsst/matplotlib.git
+obs_sdss: https://github.com/lsst/obs_sdss.git
+activemqcpp: https://github.com/lsst/activemqcpp.git
+pex_harness: https://github.com/lsst-dm/legacy-pex_harness.git
+git: https://github.com/lsst/git.git
+sims_catUtils: https://github.com/lsst/sims_catUtils.git
+sims_GalSimInterface: https://github.com/lsst/sims_GalSimInterface.git
+qserv_testdata: https://github.com/lsst/qserv_testdata
+eigen: https://github.com/lsst/eigen.git
+healpy: https://github.com/lsst/healpy.git
+mysqlclient: https://github.com/lsst/mysqlclient.git
+utils: https://github.com/lsst/utils.git
+afwdata:
+  url: https://github.com/lsst/afwdata.git
+  lfs: true
+meas_astrom: https://github.com/lsst/meas_astrom.git
+ip_diffim: https://github.com/lsst/ip_diffim.git
+meas_modelfit: https://github.com/lsst/meas_modelfit.git
+pipe_tasks: https://github.com/lsst/pipe_tasks.git
+pipe_supertask: https://github.com/lsst/pipe_supertask.git
+sims_photUtils: https://github.com/lsst/sims_photUtils.git
+skypix: https://github.com/lsst/skypix.git
+ctrl_execute: https://github.com/lsst/ctrl_execute.git
+luaxmlrpc: https://github.com/lsst/luaxmlrpc.git
+ap: https://github.com/lsst/ap.git
+sims_coordUtils: https://github.com/lsst/sims_coordUtils.git
+shapelet: https://github.com/lsst/shapelet.git
+fftw: https://github.com/lsst/fftw.git
+meas_algorithms: https://github.com/lsst/meas_algorithms.git
+pykg_config: https://github.com/lsst/pykg_config.git
+protobuf: https://github.com/lsst/protobuf.git
+sims_catalogs: https://github.com/lsst/sims_catalogs.git
+sims_catalogs_generation: https://github.com/lsst/sims_catalogs_generation.git
+partition: https://github.com/lsst/partition.git
+swig: https://github.com/lsst/swig.git
+kazoo: https://github.com/lsst/kazoo.git
+sims_data: https://github.com/lsst/sims_data.git
+daf_butlerUtils: https://github.com/lsst/daf_butlerUtils.git
+obs_base: https://github.com/lsst-dm/obs_base.git
+pyephem: https://github.com/lsst/pyephem.git
+ephem:  https://github.com/lsst/ephem.git
+ctrl_provenance: https://github.com/lsst/ctrl_provenance.git
+testing_endtoend: https://github.com/lsst/testing_endtoend.git
+sqlite: https://github.com/lsst/sqlite.git
+antlr: https://github.com/lsst/antlr.git
+datarel: https://github.com/lsst/datarel.git
+anaconda: https://github.com/lsst-dm/legacy-anaconda.git
+miniconda2: https://github.com/lsst/miniconda2.git
+miniconda3: https://github.com/lsst/miniconda3.git
+astrometry_net: https://github.com/lsst/astrometry_net.git
+sims_dustmaps: https://github.com/lsst/sims_dustmaps.git
+sims_maps:
+  url: https://github.com/lsst/sims_maps.git
+  lfs: true
+minuit2: https://github.com/lsst/minuit2.git
+lsst_libs: https://github.com/lsst/lsst_libs.git
+flask: https://github.com/lsst/flask.git
+dax_dbserv: https://github.com/lsst/dax_dbserv.git
+dax_imgserv: https://github.com/lsst/dax_imgserv.git
+dax_metaserv: https://github.com/lsst/dax_metaserv.git
+dax_webserv: https://github.com/lsst/dax_webserv.git
+dax_webserv_client: https://github.com/lsst/dax_webserv_client.git
+dax_webservcommon: https://github.com/lsst/dax_webservcommon.git
+GalSim: https://github.com/lsst/galsim.git
+galsim: https://github.com/lsst/galsim.git
+tmv: https://github.com/lsst/tmv.git
+sncosmo: https://github.com/lsst/sncosmo.git
+sims_operations: https://github.com/lsst/sims_operations.git
+display_ds9: https://github.com/lsst/display_ds9
+meas_extensions_psfex: https://github.com/lsst/meas_extensions_psfex.git
+psfex: https://github.com/lsst/psfex.git
+daf_ingest: https://github.com/lsst/daf_ingest.git
+mpi: https://github.com/lsst/mpi.git
+mpich: https://github.com/lsst/mpich.git
+mpi4py: https://github.com/lsst/mpi4py.git
+ctrl_pool: https://github.com/lsst/ctrl_pool.git
+erfa: https://github.com/lsst/erfa.git
+pal: https://github.com/lsst/pal.git
+sqlalchemy: https://github.com/lsst/sqlalchemy.git
+python_future: https://github.com/lsst/python_future.git
+capnproto: https://github.com/lsst/capnproto.git
+obs_subaru: https://github.com/lsst/obs_subaru.git
+stsci_distutils: https://github.com/lsst/stsci_distutils.git
+python_d2to1: https://github.com/lsst/python_d2to1.git
+testdata_subaru:
+  url: https://github.com/lsst/testdata_subaru.git
+  lfs: true
+obs_cfht: https://github.com/lsst/obs_cfht.git
+testdata_cfht:
+  url: https://github.com/lsst/testdata_cfht.git
+  lfs: true
+obs_decam: https://github.com/lsst/obs_decam.git
+testdata_decam:
+  url: https://github.com/lsst/testdata_decam.git
+  lfs: true
+validate_base: https://github.com/lsst/validate_base.git
+validate_drp: https://github.com/lsst/validate_drp.git
+validation_data_cfht:
+  url: https://github.com/lsst/validation_data_cfht.git
+  lfs: true
+validation_data_decam:
+  url: https://github.com/lsst/validation_data_decam.git
+  lfs: true
+validation_data_hsc:
+  url: https://github.com/lsst/validation_data_hsc.git
+  lfs: true
+pyyaml: https://github.com/lsst/pyyaml.git
+requests: https://github.com/lsst/requests.git
+ci_hsc:
+  url: https://github.com/lsst/ci_hsc.git
+  lfs: true
+lsst_ci: https://github.com/lsst/lsst_ci.git
+lsst_qa: https://github.com/lsst/lsst_qa.git
+pipe_drivers: https://github.com/lsst/pipe_drivers.git
+meas_extensions_simpleShape: https://github.com/lsst/meas_extensions_simpleShape.git
+jointcal_cholmod: https://github.com/lsst/jointcal_cholmod
+jointcal: https://github.com/lsst/jointcal
+validation_data_jointcal:
+  url: https://github.com/lsst/validation_data_jointcal.git
+  lfs: true
+ngmix: https://github.com/lsst/ngmix.git
+meas_extensions_ngmix: https://github.com/lsst/meas_extensions_ngmix.git
+meas_extensions_shapeHSM: https://github.com/lsst/meas_extensions_shapeHSM.git
+python_psutil: https://github.com/lsst/python_psutil.git
+meas_extensions_photometryKron: https://github.com/lsst/meas_extensions_photometryKron.git
+astropy: https://github.com/lsst/astropy.git
+oorb:
+  url: https://github.com/lsst/oorb.git
+  ref: lsst-dev
+sims_movingObjects: https://github.com/lsst/sims_movingObjects.git
+deploy_testing_distrib: https://github.com/lsst/deploy_testing_distrib.git
+pybind11: https://github.com/lsst/pybind11.git
+meas_mosaic: https://github.com/lsst/meas_mosaic.git
+lsst_py3: https://github.com/lsst-dm/lsst_py3.git
+obs_monocam: https://github.com/lsst/obs_monocam.git
+meas_extensions_convolved: https://github.com/lsst/meas_extensions_convolved.git
+ctrl_stats: https://github.com/lsst/ctrl_stats.git
+starlink_ast:
+  url: https://github.com/lsst/starlink_ast
+  ref: lsst-dev

--- a/tests/test_eupsmanifest.py
+++ b/tests/test_eupsmanifest.py
@@ -1,0 +1,77 @@
+#
+# LSST Data Management System
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# See COPYRIGHT file at the top of the source tree.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <https://www.lsstcorp.org/LegalNotices/>.
+#
+from __future__ import print_function
+
+import os
+import unittest
+
+from lsst.verify.metadata.eupsmanifest import Manifest
+
+
+class ManifestTestCase(unittest.TestCase):
+    """Test lsst.verify.provsrc.eupsmanifest.Manifest.
+
+    These tests are tied to data in tests/data/lsstsw/build/manifest.txt.
+    """
+
+    def setUp(self):
+        self.manifest_path = os.path.join(
+            os.path.dirname(__file__),
+            'data', 'lsstsw', 'build', 'manifest.txt')
+
+    def test_manifest(self):
+        with open(self.manifest_path) as f:
+            manifest = Manifest(f)
+
+        self.assertEqual(
+            len(manifest),
+            132)
+
+        self.assertEqual(manifest.build, 'b1988')
+
+        self.assertIn('python', manifest)
+        self.assertNotIn('ruby', manifest)
+
+        keys = [k for k in manifest]
+        self.assertEqual(len(keys), len(manifest))
+        for key in keys:
+            self.assertIn(key, manifest)
+
+        afw = manifest['afw']
+        self.assertEqual(afw.name, 'afw')
+        self.assertEqual(
+            afw.git_sha,
+            'fc355a99abe3425003b0e5fbe1e13a39644b1e95')
+        self.assertEqual(
+            afw.version,
+            '2.2016.10-22-gfc355a9')
+        self.assertEqual(
+            afw.dependencies,
+            ['daf_base', 'daf_persistence', 'pex_config', 'ndarray',
+             'cfitsio', 'wcslib', 'numpy', 'minuit2', 'eigen', 'gsl',
+             'fftw', 'utils', 'astropy', 'pyfits', 'matplotlib', 'afwdata']
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -180,6 +180,22 @@ class JobTestCase(unittest.TestCase):
             'test2_blob',
             job_1.measurements['test2.SourceCount'].blobs)
 
+    def test_metric_package_reload(self):
+        # Create a Job without Metric definitions
+        meas = Measurement('validate_drp.PA1', 15 * u.mmag)
+        measurement_set = MeasurementSet([meas])
+
+        job = Job(measurements=measurement_set)
+        job.reload_metrics_package('verify_metrics')
+
+        # Should now have metrics and specs
+        self.assertTrue(len(job.specs) > 0)
+        self.assertTrue(len(job.metrics) > 0)
+        self.assertIsInstance(
+            job.measurements['validate_drp.PA1'].metric,
+
+            Metric)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -26,7 +26,8 @@ import astropy.units as u
 import unittest
 
 from lsst.verify import (Job, Metric, ThresholdSpecification, Measurement,
-                         MeasurementSet, MetricSet, SpecificationSet, Datum)
+                         MeasurementSet, MetricSet, SpecificationSet, Datum,
+                         Blob)
 
 
 class JobTestCase(unittest.TestCase):
@@ -54,6 +55,24 @@ class JobTestCase(unittest.TestCase):
             label='N stars',
             description='Number of stars included in RMS estimate')
         self.measurement_set = MeasurementSet([self.meas_photrms])
+
+        # Metrics for Job 2
+        self.metric_test_2 = Metric('test2.SourceCount', 'Source Count', '')
+        self.blob_test_2 = Blob(
+            'test2_blob',
+            sn=Datum(50 * u.dimensionless_unscaled, label='S/N'))
+        self.metric_set_2 = MetricSet([self.metric_test_2])
+
+        # Specifications for Job 2
+        self.spec_test_2 = ThresholdSpecification(
+            'test2.SourceCount.design', 100 * u.dimensionless_unscaled, '>=')
+        self.spec_set_2 = SpecificationSet([self.spec_test_2])
+
+        # Measurements for Job 2
+        self.meas_test_2_SourceCount = Measurement(
+            self.metric_test_2, 200 * u.dimensionless_unscaled)
+        self.meas_test_2_SourceCount.link_blob(self.blob_test_2)
+        self.measurement_set_2 = MeasurementSet([self.meas_test_2_SourceCount])
 
     def test_job(self):
         """Create a Job from object sets."""
@@ -141,6 +160,25 @@ class JobTestCase(unittest.TestCase):
         self.assertEqual(
             new_job.meta['job-level-key'],
             'yes')
+
+    def test_job_iadd(self):
+        job_1 = Job(metrics=self.metric_set, specs=self.spec_set,
+                    measurements=self.measurement_set)
+        job_2 = Job(metrics=self.metric_set_2, specs=self.spec_set_2,
+                    measurements=self.measurement_set_2)
+
+        job_1 += job_2
+
+        self.assertIn(self.metric_photrms.name, job_1.metrics)
+        self.assertIn(self.metric_test_2.name, job_1.metrics)
+        self.assertIn('test.PhotRms.design', job_1.specs)
+        self.assertIn('test2.SourceCount.design', job_1.specs)
+        self.assertIn('test.PhotRms', job_1.measurements)
+        self.assertIn('test2.SourceCount', job_1.measurements)
+        self.assertIn('test.PhotRms', job_1.measurements['test.PhotRms'].blobs)
+        self.assertIn(
+            'test2_blob',
+            job_1.measurements['test2.SourceCount'].blobs)
 
 
 if __name__ == "__main__":

--- a/tests/test_lsstsw.py
+++ b/tests/test_lsstsw.py
@@ -1,0 +1,92 @@
+#
+# LSST Data Management System
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# See COPYRIGHT file at the top of the source tree.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <https://www.lsstcorp.org/LegalNotices/>.
+#
+from __future__ import print_function
+
+import os
+import unittest
+try:
+    import unittest.mock as mock
+except ImportError:
+    mock = None
+
+import lsst.verify.metadata.lsstsw as lsstsw
+
+
+class LsstswReposTestCase(unittest.TestCase):
+    """Tests for lsst.verify.provsrc.lsstsw.LsstswRepos.
+
+    These tests are tied to data in tests/data/lsstsw/
+    """
+
+    def setUp(self):
+        self.lsstsw_dirname = os.path.join(
+            os.path.dirname(__file__),
+            'data', 'lsstsw')
+
+    def test_lsstsw_repos(self):
+        lsstsw_repos = lsstsw.LsstswRepos(self.lsstsw_dirname)
+
+        self.assertEqual(
+            lsstsw_repos.manifest_path,
+            os.path.join(self.lsstsw_dirname, 'build', 'manifest.txt')
+        )
+
+        self.assertEqual(
+            lsstsw_repos.get_package_repo_path('afw'),
+            os.path.join(self.lsstsw_dirname, 'build', 'afw')
+        )
+
+        self.assertIn('afw', lsstsw_repos)
+        self.assertNotIn('ruby', lsstsw_repos)
+
+        self.assertEqual(len(lsstsw_repos), 196)
+
+        self.assertEqual(
+            lsstsw_repos.get_package_repo_url('afw'),
+            'https://github.com/lsst/afw.git'
+        )
+
+        self.assertEqual(
+            lsstsw_repos.get_package_repo_url('xrootd'),
+            'https://github.com/lsst/xrootd.git'
+        )
+
+    # FIXME not sure how to mock GitPython here. Actually complainst can't
+    # lsstsw module.
+    # @mock.patch('lsstsw.git.Repo')
+    # @unittest.skipIf(mock is None, 'unittest.mock is required.')
+    # def test_get_package_branch(self, MockRepo):
+    #     # mock git.Repo in lsst.verify.provsrc.lsstsw so that a repo's active
+    #     # branch is master and doesn't attempt to actually query the repo in
+    #     # the filesystem.
+    #     # mock.mocker.patch('lsstsw.verify.provsrc.lsstsw.git.Repo')
+    #     MockRepo.return_value.active_branch.name = 'master'
+
+    #     lsstsw_repos = lsstsw.LsstswRepos(self.lsstsw_dirname)
+    #     self.assertEqual(
+    #         lsstsw_repos.get_package_branch('afw'),
+    #         'master')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_measurementset.py
+++ b/tests/test_measurementset.py
@@ -101,6 +101,26 @@ class MeasurementSetTestCase(unittest.TestCase):
             metric_set=self.metric_set)
         self.assertEqual(meas_set, new_meas_set)
 
+    def test_measurement_set_update(self):
+        meas_set = MeasurementSet([self.pa1_meas, self.am1_meas])
+        meas_set_2 = MeasurementSet([self.am1_meas, self.pa2_meas])
+
+        meas_set.update(meas_set_2)
+
+        self.assertIs(meas_set['testing.PA1'], self.pa1_meas)
+        self.assertIs(meas_set['testing.PA2'], self.pa2_meas)
+        self.assertIs(meas_set['testing.AM1'], self.am1_meas)
+
+    def test_measurement_iadd(self):
+        meas_set = MeasurementSet([self.pa1_meas, self.am1_meas])
+        meas_set_2 = MeasurementSet([self.am1_meas, self.pa2_meas])
+
+        meas_set += meas_set_2
+
+        self.assertIs(meas_set['testing.PA1'], self.pa1_meas)
+        self.assertIs(meas_set['testing.PA2'], self.pa2_meas)
+        self.assertIs(meas_set['testing.AM1'], self.am1_meas)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_measurementset.py
+++ b/tests/test_measurementset.py
@@ -122,5 +122,48 @@ class MeasurementSetTestCase(unittest.TestCase):
         self.assertIs(meas_set['testing.AM1'], self.am1_meas)
 
 
+class MeasurementSetMetricReloadTestCase(unittest.TestCase):
+    """Use YAML in data/metrics for metric definitions."""
+
+    def setUp(self):
+        self.metrics_yaml_dirname = os.path.join(
+            os.path.dirname(__file__), 'data')
+        self.metric_set = MetricSet.load_metrics_package(
+            self.metrics_yaml_dirname)
+
+    def test_reload(self):
+        # Has Metric instance
+        pa1_meas = Measurement(
+            self.metric_set['testing.PA1'],
+            4. * u.mmag
+        )
+
+        # Don't have metric instances
+        am1_meas = Measurement(
+            'testing.AM1',
+            2. * u.marcsec
+        )
+        pa2_meas = Measurement(
+            'testing.PA2',
+            10. * u.mmag
+        )
+
+        measurements = MeasurementSet([pa1_meas, am1_meas, pa2_meas])
+        measurements.refresh_metrics(self.metric_set)
+
+        self.assertIs(
+            measurements['testing.PA1'].metric,
+            self.metric_set['testing.PA1']
+        )
+        self.assertIs(
+            measurements['testing.AM1'].metric,
+            self.metric_set['testing.AM1']
+        )
+        self.assertIs(
+            measurements['testing.PA2'].metric,
+            self.metric_set['testing.PA2']
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_metricset.py
+++ b/tests/test_metricset.py
@@ -125,6 +125,38 @@ class MetricsPackageTestCase(unittest.TestCase):
         metric_set.insert(m1)
         self.assertEqual(m1, metric_set['validate_drp.test'])
 
+    def test_update(self):
+        """Test MetricSet.update."""
+        m1 = Metric('validate_drp.test',
+                    'test', '',
+                    reference_url='example.com',
+                    reference_doc='Doc', reference_page=1)
+        new_metric_set = MetricSet([m1])
+
+        self.metric_set.update(new_metric_set)
+
+        self.assertIn('validate_drp.test', self.metric_set)
+        self.assertIn('testing.PA1', self.metric_set)
+        self.assertIn('testing.PF1', self.metric_set)
+        self.assertIn('testing.PA2', self.metric_set)
+        self.assertIn('testing.AM1', self.metric_set)
+
+    def test_iadd(self):
+        """Test __iadd__ to merging metric sets."""
+        m1 = Metric('validate_drp.test',
+                    'test', '',
+                    reference_url='example.com',
+                    reference_doc='Doc', reference_page=1)
+        new_metric_set = MetricSet([m1])
+
+        self.metric_set += new_metric_set
+
+        self.assertIn('validate_drp.test', self.metric_set)
+        self.assertIn('testing.PA1', self.metric_set)
+        self.assertIn('testing.PF1', self.metric_set)
+        self.assertIn('testing.PA2', self.metric_set)
+        self.assertIn('testing.AM1', self.metric_set)
+
 
 class VerifyMetricsParsingTestCase(unittest.TestCase):
     """Test parsing metrics from verify_metrics (an EUPS package)."""

--- a/tests/test_specification_set.py
+++ b/tests/test_specification_set.py
@@ -99,6 +99,30 @@ class TestSpecificationSet(unittest.TestCase):
         for name in names:
             self.assertTrue(isinstance(name, Name))
 
+    def test_iadd(self):
+        """Test SpecifcationSet.__iadd__."""
+        set1 = SpecificationSet([self.spec_PA1_design, self.spec_PA1_stretch])
+        set2 = SpecificationSet([self.spec_PA1_design, self.spec_PA2_design])
+
+        set1 += set2
+
+        self.assertIn('validate_drp.PA1.design', set1)
+        self.assertIn('validate_drp.PA1.stretch', set1)
+        self.assertIn('validate_drp.PA2_design_gri.srd', set1)
+        self.assertEqual(len(set1), 3)
+
+    def test_update(self):
+        """Test SpecificationSet.update()."""
+        set1 = SpecificationSet([self.spec_PA1_design, self.spec_PA1_stretch])
+        set2 = SpecificationSet([self.spec_PA1_design, self.spec_PA2_design])
+
+        set1.update(set2)
+
+        self.assertIn('validate_drp.PA1.design', set1)
+        self.assertIn('validate_drp.PA1.stretch', set1)
+        self.assertIn('validate_drp.PA2_design_gri.srd', set1)
+        self.assertEqual(len(set1), 3)
+
     def test_resolve_document(self):
         """Test specification document inheritance resolution."""
         new_spec_doc = OrderedDict([

--- a/tests/test_squash.py
+++ b/tests/test_squash.py
@@ -1,0 +1,217 @@
+#
+# LSST Data Management System
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# See COPYRIGHT file at the top of the source tree.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <https://www.lsstcorp.org/LegalNotices/>.
+#
+from __future__ import print_function
+
+import json
+import unittest
+
+import requests
+try:
+    # responses is not a formal LSST Stack dependency (yet), so we'll skip any
+    # tests that require it in environments that don't have it.
+    import responses
+except ImportError:
+    responses = None
+
+from lsst.verify import squash
+
+
+class GetDefaultTimeoutTestCase(unittest.TestCase):
+
+    def test_get_default_timeout(self):
+        self.assertEqual(
+            squash.get_default_timeout(),
+            squash._TIMEOUT
+        )
+
+
+class GetDefaultApiVersionTestCase(unittest.TestCase):
+
+    def test_get_default_api_version(self):
+        self.assertEqual(
+            squash.get_default_api_version(),
+            squash._API_VERSION
+        )
+
+
+class MakeAcceptHeaderTestCase(unittest.TestCase):
+
+    def test_make_accept_header(self):
+        self.assertEqual(
+            squash.make_accept_header(),
+            'application/json; version=' + squash.get_default_api_version()
+        )
+
+        self.assertEqual(
+            squash.make_accept_header(1.1),
+            'application/json; version=1.1'
+        )
+
+
+class GetEndpointUrlTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.api_url = 'https://example.com/api/'
+        self.endpoints = {
+            'jobs': 'https://example.com/api/jobs/'
+        }
+        squash.reset_endpoint_cache()
+
+    def tearDown(self):
+        squash.reset_endpoint_cache()
+
+    @unittest.skipIf(responses is None,
+                     'Requires `responses` PyPI package')
+    def test_jobs(self):
+        with responses.RequestsMock() as reqmock:
+            reqmock.add(responses.GET,
+                        self.api_url,
+                        json=self.endpoints,
+                        status=200,
+                        content_type='application/json')
+            jobs_url = squash.get_endpoint_url(self.api_url, 'jobs')
+
+            self.assertEqual(jobs_url, self.endpoints['jobs'])
+
+            # call again, shouldn't register a new request
+            jobs_url = squash.get_endpoint_url(self.api_url, 'jobs')
+
+            self.assertEqual(jobs_url, self.endpoints['jobs'])
+            self.assertEqual(len(reqmock.calls), 1)
+
+
+class GetTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.api_url = 'https://example.com/api/'
+        # pre-set the _ENDPOINT_URLS to use the cache, not http get
+        squash._ENDPOINT_URLS = {
+            'jobs': self.api_url + 'jobs'
+        }
+
+    def tearDown(self):
+        squash.reset_endpoint_cache()
+
+    def test_get(self):
+        with responses.RequestsMock() as reqmock:
+            reqmock.add(responses.GET,
+                        squash._ENDPOINT_URLS['jobs'],
+                        json={},
+                        status=200,
+                        content_type='application/json')
+
+            r = squash.get(self.api_url, api_endpoint='jobs')
+
+            self.assertIsInstance(r, requests.Response)
+            self.assertEqual(len(reqmock.calls), 1)
+            self.assertEqual(
+                reqmock.calls[0].request.url,
+                squash._ENDPOINT_URLS['jobs'],
+            )
+            self.assertEqual(
+                reqmock.calls[0].request.headers['Accept'],
+                'application/json; version=' + squash._API_VERSION
+            )
+
+    def test_versioned_get(self):
+        with responses.RequestsMock() as reqmock:
+            reqmock.add(responses.GET,
+                        squash._ENDPOINT_URLS['jobs'],
+                        json={},
+                        status=200,
+                        content_type='application/json')
+
+            squash.get(self.api_url, api_endpoint='jobs', version='1.2')
+
+            self.assertEqual(
+                reqmock.calls[0].request.headers['Accept'],
+                'application/json; version=1.2'
+            )
+
+    def test_raises(self):
+        with responses.RequestsMock() as reqmock:
+            reqmock.add(responses.GET,
+                        squash._ENDPOINT_URLS['jobs'],
+                        json={},
+                        status=404,
+                        content_type='application/json')
+
+            with self.assertRaises(requests.exceptions.RequestException):
+                squash.get(self.api_url, api_endpoint='jobs', version='1.2')
+
+
+class PostTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.api_url = 'https://example.com/api/'
+        # pre-set the _ENDPOINT_URLS to use the cache, not http get
+        squash._ENDPOINT_URLS = {
+            'jobs': self.api_url + 'jobs'
+        }
+
+    def tearDown(self):
+        squash.reset_endpoint_cache()
+
+    def test_json_post(self):
+        with responses.RequestsMock() as reqmock:
+            reqmock.add(responses.POST,
+                        squash._ENDPOINT_URLS['jobs'],
+                        json={},
+                        status=201,
+                        content_type='application/json')
+
+            r = squash.post(self.api_url, api_endpoint='jobs',
+                            json_doc={'key': 'value'},
+                            api_user='foo', api_password='bar')
+
+            self.assertIsInstance(r, requests.Response)
+            self.assertEqual(len(reqmock.calls), 1)
+            self.assertEqual(
+                reqmock.calls[0].request.url,
+                squash._ENDPOINT_URLS['jobs'],
+            )
+            self.assertEqual(
+                reqmock.calls[0].request.headers['Accept'],
+                'application/json; version=' + squash._API_VERSION
+            )
+            self.assertEqual(
+                json.loads(reqmock.calls[0].request.body),
+                {'key': 'value'}
+            )
+
+    def test_raises(self):
+        with responses.RequestsMock() as reqmock:
+            reqmock.add(responses.POST,
+                        squash._ENDPOINT_URLS['jobs'],
+                        json={},
+                        status=503,
+                        content_type='application/json')
+
+            with self.assertRaises(requests.exceptions.RequestException):
+                squash.post(self.api_url, api_endpoint='jobs',
+                            json_doc={},
+                            api_user='foo', api_password='bar')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ups/verify.table
+++ b/ups/verify.table
@@ -1,10 +1,12 @@
 setupRequired(python_future)
 setupRequired(pyyaml)
+setupRequired(requests)
 setupRequired(numpy)
 setupRequired(astropy)
 setupRequired(sconsUtils)
 setupRequired(utils)
 setupRequired(pex_exceptions)
+setupRequired(log)
 
 # verify_metrics is the default metrics repo and is used in tests
 setupRequired(verify_metrics)


### PR DESCRIPTION
`dispatch_verify.py` acts as an upload client to send verification job JSON fields to SQUASH.

Some features:

- Can take multiple Job JSON files; each is merged
- Metric definitions can be added to a Job, ensuring that units are consistent and normalized to the metric definition before sending to SQUASH.
- Instead of, or in addition to, upload to SQUASH, `dispatch_verify.py` can also save the merged JSON document for later processing or archival. It can also print it out to standard output.
- Using an `--env=jenkins` flag, Jenkins environment information is added to the Job metadata.
- Using an `--lsstsw` flag, lsstsw package information is added to the Job metadata.
- Both CLI flag and environment variable-based configuration is supported. The CLI flags override environment variables.