### PR TITLE
DM-10357: Tabulated specification test reports

### DIFF
--- a/python/lsst/verify/blob.py
+++ b/python/lsst/verify/blob.py
@@ -156,3 +156,27 @@ class Blob(JsonSerializationMixin):
 
     def __ne__(self, other):
         return not self.__eq__(other)
+
+    def keys(self):
+        """Get keys of blob items.
+
+        Returns
+        -------
+        keys : sequence of `str`
+            Sequence of keys to items in the Blob.
+        """
+        return self._datums.keys()
+
+    def items(self):
+        """Get pairs of keys and values in the Blob.
+
+        Yields
+        ------
+        keyval : tuple
+            Tuple of:
+
+            - key (`str`)
+            - datum (`lsst.verify.Datum`)
+        """
+        for key, val in self._datums.items():
+            yield key, val

--- a/python/lsst/verify/blobset.py
+++ b/python/lsst/verify/blobset.py
@@ -133,6 +133,16 @@ class BlobSet(JsonSerializationMixin):
             count_str = '{count:d} Blobs'.format(count=count)
         return '<BlobSet: {0}>'.format(count_str)
 
+    def keys(self):
+        """Get a sequence of blob identifiers, which are keys to the BlobSet.
+
+        Returns
+        -------
+        keys : sequence
+            Sequence of `Blob` identifiers.
+        """
+        return self._items.keys()
+
     def items(self):
         """Iterate over (identifier, `Blob`) pairs in the set.
 

--- a/python/lsst/verify/job.py
+++ b/python/lsst/verify/job.py
@@ -329,3 +329,57 @@ class Job(JsonSerializationMixin):
         squash.post(api_url, 'jobs', json_doc=job_json,
                     api_user=api_user, api_password=api_password,
                     **kwargs)
+
+    def report(self, name=None, spec_tags=None, metric_tags=None):
+        """Create a verification report that lists the pass/fail status of
+        measurements against specifications in this job.
+
+        In a Jupyter notebook, this report can be shown as an inline table.
+
+        Parameters
+        ----------
+        name : `str` or `lsst.verify.Name`, optional
+            A package or metric name to subset specifications by. When set,
+            only measurement and specification combinations belonging to that
+            package or metric are included in the report.
+        spec_tags : sequence of `str`, optional
+            A set of specification tag strings. when given, only
+            specifications that have all the given tags are included in the
+            report. For example, ``spec_tags=['LPM-17', 'minimum']``.
+        metric_tags : sequence of `str`, optional
+            A set of metric tag strings. When given, only specifications
+            belonging to metrics that posess **all** given tags are included
+            in the report. For example,
+            ``metric_tags=['LPM-17', 'photometry']`` selects sepifications
+            that have both the ``'LPM-17'`` and ``'photometry'`` tags.
+
+        Returns
+        -------
+        report : `lsst.verify.Report`
+            Report instance. In a Jupyter notebook, you can view the report
+            by calling `Report.show`.
+
+        See also
+        --------
+        `lsst.verify.SpecificationSet.report`
+
+        Notes
+        -----
+        This method uses the `lsst.verify.SpecificationSet.report` API to
+        create the `lsst.verify.Report`, automatically inserting the `Job`\ 's
+        measurements and metadata for filtering specifiation tests.
+
+        In a Jupyter notebook environment, use the `lsst.verify.Report.show`
+        method to view an interactive HTML table.
+
+        .. code-block:: python
+
+           job = lsst.verify.Job()
+           # ...
+           report = job.report()
+           report.show()
+        """
+        report = self.specs.report(self.measurements, meta=self.meta,
+                                   name=name, metric_tags=metric_tags,
+                                   spec_tags=spec_tags, metrics=self.metrics)
+        return report

--- a/python/lsst/verify/jobmetadata.py
+++ b/python/lsst/verify/jobmetadata.py
@@ -34,6 +34,7 @@ except ImportError:
     # future 0.16.0 doesn't do the import right; this will be fixed in 0.16.1
     # https://github.com/PythonCharmers/python-future/issues/226
     from future.backports.misc import ChainMap
+import json
 import re
 
 from .jsonmixin import JsonSerializationMixin
@@ -169,10 +170,14 @@ class Metadata(JsonSerializationMixin):
         return not self.__eq__(other)
 
     def __str__(self):
-        return str(self._chain)
+        json_data = self.json
+        return json.dumps(json_data, sort_keys=True, indent=4)
 
     def __repr__(self):
         return repr(self._chain)
+
+    def _repr_html_(self):
+        return self.__str__()
 
     def keys(self):
         return [key for key in self]

--- a/python/lsst/verify/jsonmixin.py
+++ b/python/lsst/verify/jsonmixin.py
@@ -95,7 +95,7 @@ class JsonSerializationMixin(with_metaclass(abc.ABCMeta, object)):
             return v.json
         elif isinstance(v, dict):
             return JsonSerializationMixin.jsonify_dict(v)
-        elif isinstance(v, (list, tuple)):
+        elif isinstance(v, (list, tuple, set)):
             return JsonSerializationMixin._jsonify_list(v)
         else:
             return v

--- a/python/lsst/verify/measurement.py
+++ b/python/lsst/verify/measurement.py
@@ -193,6 +193,17 @@ class Measurement(JsonSerializationMixin):
     def __str__(self):
         return "{self.metric_name!s}: {self.quantity!s}".format(self=self)
 
+    def _repr_latex_(self):
+        """Get a LaTeX-formatted string representation of the measurement
+        quantity (used in Jupyter notebooks).
+
+        Returns
+        -------
+        rep : `str`
+            String representation.
+        """
+        return '{0.value:0.1f} {0.unit:latex_inline}'.format(self.quantity)
+
     @property
     def description(self):
         """Description of the metric (`str`, or `None` if

--- a/python/lsst/verify/measurementset.py
+++ b/python/lsst/verify/measurementset.py
@@ -168,6 +168,16 @@ class MeasurementSet(JsonSerializationMixin):
             count_str = '{count:d} Measurements'.format(count=count)
         return '<MeasurementSet: {0}>'.format(count_str)
 
+    def keys(self):
+        """Get a sequence of metric names contained in the measurement set.
+
+        Returns
+        -------
+        keys : sequence of `Name`
+            Sequence of names of metrics for measurements in the set.
+        """
+        return self._items.keys()
+
     def items(self):
         """Iterete over (`Name`, `Measurement`) pairs in the set.
 

--- a/python/lsst/verify/metric.py
+++ b/python/lsst/verify/metric.py
@@ -69,9 +69,6 @@ class Metric(JsonSerializationMixin):
     description = None
     """Short description of the metric (`str`)."""
 
-    tags = None
-    """Tag labels to group the metric (`list` of `str`)."""
-
     reference_doc = None
     """Name of the document that specifies this metric (`str`)."""
 
@@ -87,9 +84,7 @@ class Metric(JsonSerializationMixin):
         self.description = description
         self.unit = u.Unit(unit)
         if tags is None:
-            self.tags = []
-        elif isinstance(tags, basestring):
-            self.tags = [tags]
+            self.tags = set()
         else:
             # FIXME DM-8477 Need type checking that tags are actually strings
             # and are a set.
@@ -188,6 +183,18 @@ class Metric(JsonSerializationMixin):
     @unit_str.setter
     def unit_str(self, value):
         self.unit = u.Unit(value)
+
+    @property
+    def tags(self):
+        """Tag labels (`set` of `str`)."""
+        return self._tags
+
+    @tags.setter
+    def tags(self, t):
+        # Ensure that tags is always a set.
+        if isinstance(t, basestring):
+            t = [t]
+        self._tags = set(t)
 
     @property
     def reference(self):

--- a/python/lsst/verify/metricset.py
+++ b/python/lsst/verify/metricset.py
@@ -320,7 +320,7 @@ class MetricSet(JsonSerializationMixin):
         for item in self._metrics.items():
             yield item
 
-    def subset(self, package=None, tag=None):
+    def subset(self, package=None, tags=None):
         """Create a new `MetricSet` with metrics belonging to a single
         package and/or tag.
 
@@ -331,8 +331,9 @@ class MetricSet(JsonSerializationMixin):
             is ``'pkg_a'``, then metric ``'pkg_a.metric_1'`` would be
             **included** in the subset, while ``'pkg_b.metric_2'`` would be
             **excluded**.
-        tag : `str`, optional
-            Tag to select metrics by.
+        tags : sequence of `str`, optional
+            Tags to select metrics by. These tags must be a subset (``<=``)
+            of the `Metric.tags` for the metric to be selected.
 
         Returns
         -------
@@ -350,18 +351,21 @@ class MetricSet(JsonSerializationMixin):
         if package is not None and not isinstance(package, Name):
             package = Name(package=package)
 
-        if package is not None and tag is None:
+        if tags is not None:
+            tags = set(tags)
+
+        if package is not None and tags is None:
             metrics = [metric for metric_name, metric in self._metrics.items()
                        if metric_name in package]
 
-        elif package is not None and tag is not None:
+        elif package is not None and tags is not None:
             metrics = [metric for metric_name, metric in self._metrics.items()
                        if metric_name in package
-                       if tag in metric.tags]
+                       if tags <= metric.tags]
 
-        elif package is None and tag is not None:
+        elif package is None and tags is not None:
             metrics = [metric for metric_name, metric in self._metrics.items()
-                       if tag in metric.tags]
+                       if tags <= metric.tags]
 
         else:
             metrics = []

--- a/python/lsst/verify/metricset.py
+++ b/python/lsst/verify/metricset.py
@@ -303,6 +303,9 @@ class MetricSet(JsonSerializationMixin):
         """
         self[metric.name] = metric
 
+    def keys(self):
+        return self._metrics.keys()
+
     def items(self):
         """Iterate over ``(name, metric)`` pairs in the set.
 

--- a/python/lsst/verify/metricset.py
+++ b/python/lsst/verify/metricset.py
@@ -27,6 +27,8 @@ __all__ = ['MetricSet']
 import os
 import glob
 
+from astropy.table import Table
+
 import lsst.pex.exceptions
 from lsst.utils import getPackageDir
 from .jsonmixin import JsonSerializationMixin
@@ -384,3 +386,36 @@ class MetricSet(JsonSerializationMixin):
         """
         for _, metric in other.items():
             self.insert(metric)
+
+    def _repr_html_(self):
+        """Make an HTML representation of metrics for Jupyter notebooks.
+        """
+        name_col = []
+        tags_col = []
+        units_col = []
+        description_col = []
+        reference_col = []
+
+        metric_names = list(self.keys())
+        metric_names.sort()
+
+        for metric_name in metric_names:
+            metric = self[metric_name]
+
+            name_col.append(str(metric_name))
+
+            tags = list(metric.tags)
+            tags.sort()
+            tags_col.append(', '.join(tags))
+
+            units_col.append("{0:latex}".format(metric.unit))
+
+            description_col.append(metric.description)
+
+            reference_col.append(metric.reference)
+
+        table = Table([name_col, description_col, units_col, reference_col,
+                       tags_col],
+                      names=['Name', 'Description', 'Units', 'Reference',
+                             'Tags'])
+        return table._repr_html_()

--- a/python/lsst/verify/report.py
+++ b/python/lsst/verify/report.py
@@ -1,0 +1,112 @@
+#
+# LSST Data Management System
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# See COPYRIGHT file at the top of the source tree.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <https://www.lsstcorp.org/LegalNotices/>.
+#
+from __future__ import print_function, division
+
+__all__ = ['Report']
+
+from astropy.table import Table
+
+from .naming import Name
+
+
+class Report(object):
+    """Report tabulating specification pass/fail status for a set of
+    measurements.
+
+    Parameters
+    ----------
+    measurements : `lsst.verify.MeasurementSet`
+        Measurements to be tested.
+    specs : `lsst.verify.SpecificationSet`
+        Specifications to test measurements against. These specifications
+        are assumed to be relevant to the measurements. Using
+        `SpecificationSet.subset`, passing in job metadata, to ensure this.
+    """
+
+    def __init__(self, measurements, specs):
+        self._meas_set = measurements
+        self._spec_set = specs
+
+    def make_table(self):
+        """Make an table summarizing specification tests of measurements.
+
+        Returns
+        -------
+        table : `astropy.table.Table`
+            Table with columns:
+
+            - **Status**
+            - **Specification**
+            - **Measurement**
+            - **Test**
+        """
+        # Columns for the table
+        statuses = []
+        spec_name_items = []
+        measurements = []
+        tests = []
+
+        spec_names = list(self._spec_set.keys())
+        spec_names.sort()
+
+        for spec_name in spec_names:
+            # Test if there is a measurement for this specification,
+            # if not, we just skip it.
+            metric_name = Name(package=spec_name.package,
+                               metric=spec_name.metric)
+            try:
+                meas = self._meas_set[metric_name]
+            except KeyError:
+                # No measurement for this specification, just skip it.
+                continue
+
+            spec = self._spec_set[spec_name]
+
+            if spec.check(meas.quantity):
+                # Passed
+                # http://emojipedia.org/white-heavy-check-mark/
+                statuses.append(u'\U00002705')
+            else:
+                # Failed.
+                # http://emojipedia.org/cross-mark/
+                statuses.append(u'\U0000274C')
+
+            spec_name_items.append(str(spec_name))
+
+            measurements.append(meas._repr_latex_())
+
+            tests.append(spec._repr_latex_())
+
+        table = Table([statuses, spec_name_items, measurements, tests],
+                      names=['Status', 'Specification', 'Measurement', 'Test'])
+        return table
+
+    def _repr_html_(self):
+        """HTML representation of the report for Jupyter notebooks."""
+        table = self.make_table()
+        return table._repr_html_()
+
+    def show(self):
+        """Display the report in a Jupyter notebook."""
+        table = self.make_table()
+        return table.show_in_notebook(show_row_index='')

--- a/python/lsst/verify/report.py
+++ b/python/lsst/verify/report.py
@@ -59,12 +59,16 @@ class Report(object):
             - **Specification**
             - **Measurement**
             - **Test**
+            - **Metric Tags**
+            - **Spec. Tags**
         """
         # Columns for the table
         statuses = []
         spec_name_items = []
         measurements = []
         tests = []
+        metric_tags = []
+        spec_tags = []
 
         spec_names = list(self._spec_set.keys())
         spec_names.sort()
@@ -97,8 +101,23 @@ class Report(object):
 
             tests.append(spec._repr_latex_())
 
-        table = Table([statuses, spec_name_items, measurements, tests],
-                      names=['Status', 'Specification', 'Measurement', 'Test'])
+            tags = list(spec.tags)
+            tags.sort()
+            spec_tags.append(', '.join(tags))
+
+            metric = meas.metric
+            if metric is None:
+                # no metric is available, this is the default
+                metric_tags.append('N/A')
+            else:
+                tags = list(metric.tags)
+                tags.sort()
+                metric_tags.append(', '.join(tags))
+
+        table = Table([statuses, spec_name_items, measurements, tests,
+                       metric_tags, spec_tags],
+                      names=['Status', 'Specification', 'Measurement', 'Test',
+                             'Metric Tags', 'Spec. Tags'])
         return table
 
     def _repr_html_(self):

--- a/python/lsst/verify/spec/base.py
+++ b/python/lsst/verify/spec/base.py
@@ -26,6 +26,7 @@ __all__ = ["Specification"]
 
 import abc
 from future.utils import with_metaclass
+from past.builtins import basestring
 
 from ..jsonmixin import JsonSerializationMixin
 from ..metaquery import MetadataQuery
@@ -47,6 +48,9 @@ class Specification(with_metaclass(abc.ABCMeta, JsonSerializationMixin)):
     """
 
     def __init__(self, name, **kwargs):
+        # interal object behind self.tags
+        self._tags = set()
+
         # name attibute must be a Name instance representing a specification
         if not isinstance(name, Name):
             self._name = Name(spec=name)
@@ -61,6 +65,9 @@ class Specification(with_metaclass(abc.ABCMeta, JsonSerializationMixin)):
         else:
             self.metadata_query = MetadataQuery()
 
+        if 'tags' in kwargs:
+            self.tags = kwargs['tags']
+
     @property
     def name(self):
         """Specification name (`lsst.verify.Name`)."""
@@ -71,6 +78,18 @@ class Specification(with_metaclass(abc.ABCMeta, JsonSerializationMixin)):
         """Name of the metric this specification corresponds to
         (`lsst.verify.Name`)."""
         return Name(package=self.name.package, metric=self.name.metric)
+
+    @property
+    def tags(self):
+        """Tag labels (`set` of `str`)."""
+        return self._tags
+
+    @tags.setter
+    def tags(self, t):
+        # Ensure that tags is always a set.
+        if isinstance(t, basestring):
+            t = [t]
+        self._tags = set(t)
 
     @abc.abstractproperty
     def type(self):
@@ -97,7 +116,8 @@ class Specification(with_metaclass(abc.ABCMeta, JsonSerializationMixin)):
                 'name': str(self.name),
                 'type': self.type,
                 self.type: self._serialize_type(),
-                'metadata_query': self.metadata_query
+                'metadata_query': self.metadata_query,
+                'tags': self.tags
             }
         )
 

--- a/python/lsst/verify/spec/base.py
+++ b/python/lsst/verify/spec/base.py
@@ -66,6 +66,12 @@ class Specification(with_metaclass(abc.ABCMeta, JsonSerializationMixin)):
         """Specification name (`lsst.verify.Name`)."""
         return self._name
 
+    @property
+    def metric_name(self):
+        """Name of the metric this specification corresponds to
+        (`lsst.verify.Name`)."""
+        return Name(package=self.name.package, metric=self.name.metric)
+
     @abc.abstractproperty
     def type(self):
         """Specification type (`str`)."""

--- a/python/lsst/verify/spec/threshold.py
+++ b/python/lsst/verify/spec/threshold.py
@@ -102,6 +102,23 @@ class ThresholdSpecification(Specification):
             self.threshold,
             self.operator_str)
 
+    def __str__(self):
+        return '{self.operator_str} {self.threshold}'.format(self=self)
+
+    def _repr_latex_(self):
+        """Get a LaTeX-formatted string representation of the threshold
+        specification test.
+
+        Returns
+        -------
+        rep : `str`
+            String representation.
+        """
+        template = ('$x$ {self.operator_str} '
+                    '{self.threshold.value} '
+                    '{self.threshold.unit:latex_inline}')
+        return template.format(self=self)
+
     @property
     def datum(self):
         """Representation of this `ThresholdSpecification`\ 's threshold as

--- a/python/lsst/verify/spec/threshold.py
+++ b/python/lsst/verify/spec/threshold.py
@@ -51,6 +51,11 @@ class ThresholdSpecification(Specification):
         so that ``measurement {{ operator }} threshold quantity`` is the
         specification test. Can be one of: ``'<'``, ``'<='``, ``'>'``,
         ``'>='``, ``'=='``, or ``'!='``.
+    metadata_query : `dict`, optional
+        Dictionary of key-value term's that the measurement's metadata must
+        have for this specification to apply.
+    tags : sequence of `str`, optional
+        Sequence of tags that group this specification with others.
     kwargs : `dict`
         Keyword arguments passed directly to the
         `lsst.validate.base.Specification` constructor.

--- a/python/lsst/verify/specset.py
+++ b/python/lsst/verify/specset.py
@@ -644,6 +644,16 @@ class SpecificationSet(JsonSerializationMixin):
         self.update(other)
         return self
 
+    def keys(self):
+        """Get a sequence of specification names, which are keys to the set.
+
+        Returns
+        -------
+        keys : sequence of `Name`
+            Keys to the specification set.
+        """
+        return self._specs.keys()
+
     def items(self):
         """Iterate over name, specification pairs.
 

--- a/python/lsst/verify/specset.py
+++ b/python/lsst/verify/specset.py
@@ -30,6 +30,8 @@ from collections import OrderedDict
 import os
 import re
 
+from astropy.table import Table
+
 import lsst.pex.exceptions
 from lsst.utils import getPackageDir
 
@@ -924,6 +926,32 @@ class SpecificationSet(JsonSerializationMixin):
                                   spec_tags=spec_tags,
                                   metric_tags=metric_tags, metrics=metrics)
         return Report(measurements, spec_subset)
+
+    def _repr_html_(self):
+        """Make an HTML representation of the SpecificationSet for Jupyter
+        notebooks.
+        """
+        name_col = []
+        tags_col = []
+        test_col = []
+
+        names = list(self.keys())
+        names.sort()
+
+        for name in names:
+            spec = self[name]
+
+            name_col.append(str(name))
+
+            test_col.append(spec._repr_latex_())
+
+            tags = list(spec.tags)
+            tags.sort()
+            tags_col.append(', '.join(tags))
+
+        table = Table([name_col, test_col, tags_col],
+                      names=['Name', 'Test', 'Tags'])
+        return table._repr_html_()
 
 
 class SpecificationPartial(object):

--- a/python/lsst/verify/specset.py
+++ b/python/lsst/verify/specset.py
@@ -787,7 +787,8 @@ class SpecificationSet(JsonSerializationMixin):
             # No inheritance to resolve
             return spec_doc
 
-    def subset(self, name=None, meta=None):
+    def subset(self, name=None, meta=None, spec_tags=None, metric_tags=None,
+               metrics=None):
         """Create a new `SpecificationSet` with specifications belonging to
         a single package or metric, and that apply to the given metadata.
 
@@ -803,6 +804,21 @@ class SpecificationSet(JsonSerializationMixin):
             If supplied, only specifications that apply to the given metadata
             are included in the subset. Metadata is usually obtained from
             the `Job.meta` attribute of a `Job` instance.
+        spec_tags : sequence of `str`, optional
+            A set of specification tag strings. when given, only
+            specifications that have all the given tags are included in the
+            report. For example, ``spec_tags=['LPM-17', 'minimum']``.
+        metric_tags : sequence of `str`, optional
+            A set of metric tag strings. When given, only specifications
+            belonging to metrics that posess **all** given tags are included
+            in the report. For example,
+            ``metric_tags=['LPM-17', 'photometry']`` selects sepifications
+            that have both the ``'LPM-17'`` and ``'photometry'`` tags. If
+            set, also provide a `lsst.verify.MetricSet` with the ``metrics``
+            argument.
+        metrics : `lsst.verify.MetricSet`
+            `~lsst.verify.MetricSet` with metric definitions. This is only
+            needed if a ``metric_tags`` argument is provided.
 
         Returns
         -------
@@ -812,6 +828,11 @@ class SpecificationSet(JsonSerializationMixin):
             compatible with the job metadata.. Any partials in
             the SpecificationSet are also included in ``spec_subset``.
         """
+        if metric_tags is not None and metrics is None:
+            message = ('A MetricSet must be provided through the metrics '
+                       'argument when subsetting ith metric_tags.')
+            raise ValueError(message)
+
         all_partials = [partial
                         for partial_name, partial in self._partials.items()]
 
@@ -840,9 +861,25 @@ class SpecificationSet(JsonSerializationMixin):
             spec_subset = SpecificationSet(specifications=specs,
                                            partials=all_partials)
 
+        # Filter by specifiation tags
+        if spec_tags is not None:
+            spec_tags = set(spec_tags)
+            specs = [spec for spec_name, spec in spec_subset.items()
+                     if spec_tags <= spec.tags]
+
+            spec_subset = SpecificationSet(specifications=specs,
+                                           partials=all_partials)
+
+        # Filter by metric tags
+        if metric_tags is not None:
+            metric_tags = set(metric_tags)
+            specs = [spec for spec_name, spec in spec_subset.items()
+                     if metric_tags <= metrics[spec.metric_name].tags]
+
         return spec_subset
 
-    def report(self, measurements, name=None, meta=None):
+    def report(self, measurements, name=None, meta=None, spec_tags=None,
+               metric_tags=None, metrics=None):
         """Create a report that details specification tests against the given
         measurements.
 
@@ -851,18 +888,41 @@ class SpecificationSet(JsonSerializationMixin):
         measurements : `lsst.verify.MeasurementSet`
             Measurements to test.
         name : `str` or `lsst.verify.Name`, optional
-            Package or metric name to limit the report to.
+            A package or metric name to subset specifications by. When set,
+            only measurement and specification combinations belonging to that
+            package or metric are included in the report.
         meta : `lsst.verifify.Metadata`, optional
             Job metadata to ensure the specifications are relevant to the
             measurements. Typically accessed as `Job.meta`.
+        spec_tags : sequence of `str`, optional
+            A set of specification tag strings. when given, only
+            specifications that have all the given tags are included in the
+            report. For example, ``spec_tags=['LPM-17', 'minimum']``.
+        metric_tags : sequence of `str`, optional
+            A set of metric tag strings. When given, only specifications
+            belonging to metrics that posess **all** given tags are included
+            in the report. For example,
+            ``metric_tags=['LPM-17', 'photometry']`` selects sepifications
+            that have both the ``'LPM-17'`` and ``'photometry'`` tags. If
+            set, also provide a `lsst.verify.MetricSet` with the ``metrics``
+            argument.
+        metrics : `lsst.verify.MetricSet`
+            `~lsst.verify.MetricSet` with metric definitions. This is only
+            needed if a ``metric_tags`` argument is provided.
 
         Returns
         -------
         report : `lsst.verify.Report`
             Report instance. In a Jupyter notebook, you can view the report
             by calling `Report.show`.
+
+        See also
+        --------
+        `lsst.verify.Job.report`
         """
-        spec_subset = self.subset(name=name, meta=meta)
+        spec_subset = self.subset(name=name, meta=meta,
+                                  spec_tags=spec_tags,
+                                  metric_tags=metric_tags, metrics=metrics)
         return Report(measurements, spec_subset)
 
 

--- a/python/lsst/verify/specset.py
+++ b/python/lsst/verify/specset.py
@@ -39,6 +39,7 @@ from .naming import Name
 from .spec.base import Specification
 from .spec.threshold import ThresholdSpecification
 from .yamlutils import merge_documents, load_all_ordered_yaml
+from .report import Report
 
 
 # Pattern for SpecificationPartial names
@@ -840,6 +841,29 @@ class SpecificationSet(JsonSerializationMixin):
                                            partials=all_partials)
 
         return spec_subset
+
+    def report(self, measurements, name=None, meta=None):
+        """Create a report that details specification tests against the given
+        measurements.
+
+        Parameters
+        ----------
+        measurements : `lsst.verify.MeasurementSet`
+            Measurements to test.
+        name : `str` or `lsst.verify.Name`, optional
+            Package or metric name to limit the report to.
+        meta : `lsst.verifify.Metadata`, optional
+            Job metadata to ensure the specifications are relevant to the
+            measurements. Typically accessed as `Job.meta`.
+
+        Returns
+        -------
+        report : `lsst.verify.Report`
+            Report instance. In a Jupyter notebook, you can view the report
+            by calling `Report.show`.
+        """
+        spec_subset = self.subset(name=name, meta=meta)
+        return Report(measurements, spec_subset)
 
 
 class SpecificationPartial(object):

--- a/tests/test_metricset.py
+++ b/tests/test_metricset.py
@@ -198,14 +198,14 @@ class MetricSetSubsetTestCase(unittest.TestCase):
         self.assertIn(self.m3.name, subset)
 
     def test_subset_testing_tag(self):
-        subset = self.metric_set.subset(tag='testing')
+        subset = self.metric_set.subset(tags=['testing'])
         self.assertEqual(len(subset), 2)
         self.assertIn(self.m1.name, subset)
         self.assertNotIn(self.m2.name, subset)
         self.assertIn(self.m3.name, subset)
 
     def test_subset_A_testing_tag(self):
-        subset = self.metric_set.subset(package='pkgA', tag='testing')
+        subset = self.metric_set.subset(package='pkgA', tags=['testing'])
         self.assertEqual(len(subset), 1)
         self.assertIn(self.m1.name, subset)
         self.assertNotIn(self.m2.name, subset)
@@ -216,9 +216,9 @@ class MetricSetSerializationTestCase(unittest.TestCase):
     """Test JSON serialization and deserialization for MetricSets."""
 
     def setUp(self):
-        self.m1 = Metric('pkgA.m1', 'In pkgA', '', tags='testing')
-        self.m2 = Metric('pkgA.m2', 'In pkgA', '', tags='other')
-        self.m3 = Metric('pkgB.m3', 'In pkgB', '', tags='testing')
+        self.m1 = Metric('pkgA.m1', 'In pkgA', '', tags=['testing'])
+        self.m2 = Metric('pkgA.m2', 'In pkgA', '', tags=['other'])
+        self.m3 = Metric('pkgB.m3', 'In pkgB', '', tags=['testing'])
         self.metric_set = MetricSet([self.m1, self.m2, self.m3])
 
     def test_serialization(self):

--- a/tests/test_squash.py
+++ b/tests/test_squash.py
@@ -112,6 +112,8 @@ class GetTestCase(unittest.TestCase):
     def tearDown(self):
         squash.reset_endpoint_cache()
 
+    @unittest.skipIf(responses is None,
+                     'Requires `responses` PyPI package')
     def test_get(self):
         with responses.RequestsMock() as reqmock:
             reqmock.add(responses.GET,
@@ -133,6 +135,8 @@ class GetTestCase(unittest.TestCase):
                 'application/json; version=' + squash._API_VERSION
             )
 
+    @unittest.skipIf(responses is None,
+                     'Requires `responses` PyPI package')
     def test_versioned_get(self):
         with responses.RequestsMock() as reqmock:
             reqmock.add(responses.GET,
@@ -148,6 +152,8 @@ class GetTestCase(unittest.TestCase):
                 'application/json; version=1.2'
             )
 
+    @unittest.skipIf(responses is None,
+                     'Requires `responses` PyPI package')
     def test_raises(self):
         with responses.RequestsMock() as reqmock:
             reqmock.add(responses.GET,
@@ -172,6 +178,8 @@ class PostTestCase(unittest.TestCase):
     def tearDown(self):
         squash.reset_endpoint_cache()
 
+    @unittest.skipIf(responses is None,
+                     'Requires `responses` PyPI package')
     def test_json_post(self):
         with responses.RequestsMock() as reqmock:
             reqmock.add(responses.POST,
@@ -199,6 +207,8 @@ class PostTestCase(unittest.TestCase):
                 {'key': 'value'}
             )
 
+    @unittest.skipIf(responses is None,
+                     'Requires `responses` PyPI package')
     def test_raises(self):
         with responses.RequestsMock() as reqmock:
             reqmock.add(responses.POST,


### PR DESCRIPTION
Report class uses astropy tables to tabulate specifications and the pass/fail status of measurements.

Report is specifically meant to be used for creating verification documentation in a Jupyter notebook.