### PR TITLE
DM-10625: Make a copy of spec when resolving it

### DIFF
--- a/python/lsst/verify/specset.py
+++ b/python/lsst/verify/specset.py
@@ -27,6 +27,7 @@ __all__ = ['SpecificationSet']
 from past.builtins import basestring
 
 from collections import OrderedDict
+import copy
 import os
 import re
 
@@ -720,6 +721,10 @@ class SpecificationSet(JsonSerializationMixin):
            Raised when a document's bases cannot be resolved (an inherited
            `~lsst.validate.base.Specification` cannot be found in the repo).
         """
+        # Create a copy of the spec_doc so that if the resolution is aborted
+        # we haven't modified the original document
+        spec_doc = copy.deepcopy(spec_doc)
+
         # Goal is to process all specifications and partials mentioned in
         # the 'base' field (first in, first out) and merge their information
         # to the spec_doc.


### PR DESCRIPTION
If a specification has a base that can't be resolved, then an exception is thrown in the `resolve_document()` method, indicating that it should be added to a retry pile. But we're also modifying that specification in the `resolve_document()` method. So when we do retry the resolution, the specification may not be in a good state.

Doing a deep copy of the original specification in `resolve_document()` solves all these things.