### PR TITLE
DM-11514: Add pytest_flake8 dependency

### DIFF
--- a/ups/verify.table
+++ b/ups/verify.table
@@ -7,6 +7,7 @@ setupRequired(sconsUtils)
 setupRequired(utils)
 setupRequired(pex_exceptions)
 setupRequired(log)
+setupRequired(pytest_flake8)
 
 # verify_metrics is the default metrics repo and is used in tests
 setupRequired(verify_metrics)


### PR DESCRIPTION
This change add `pytest_flake8` as an EUPS dependency so that pytest can be used by `sconsUtils` for testing.

****

- [x] Passes Jenkins CI.
- [x] Documentation is up-to-date.

