### PR TITLE
DM-12269: Add SpecificationSet.subset(required_meta=...) mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ bin/*.py
 examples/*.list
 .coverage
 htmlcov
+pytest_session.txt

--- a/python/lsst/verify/metaquery.py
+++ b/python/lsst/verify/metaquery.py
@@ -38,7 +38,7 @@ class MetadataQuery(JsonSerializationMixin):
 
     Examples
     --------
-    A MetadataQuery returns `True` if all keys-value terms found in
+    A MetadataQuery returns `True` if all key-value terms found in
     `MetadataQuery.terms` are equal to key-value metadata items.
 
     >>> metadata = {'filter': 'r', 'camera': 'MegaCam'}

--- a/python/lsst/verify/spec/base.py
+++ b/python/lsst/verify/spec/base.py
@@ -139,7 +139,7 @@ class Specification(with_metaclass(abc.ABCMeta, JsonSerializationMixin)):
         """
         pass
 
-    def query_metadata(self, metadata):
+    def query_metadata(self, metadata, arg_driven=False):
         """Query a Job's metadata to determine if this specification applies.
 
         Parameters
@@ -147,11 +147,28 @@ class Specification(with_metaclass(abc.ABCMeta, JsonSerializationMixin)):
         metadata : `lsst.verify.Metadata` or `dict`-type
             Metadata mapping. Typically this is the `lsst.verify.Job.meta`
             attribute.
+        arg_driven : `bool`, optional
+            If `False` (default), ``metadata`` matches the ``MetadataQuery``
+            if ``metadata`` has all the terms defined in ``MetadataQuery``,
+            and those terms match. If ``metadata`` has more terms than
+            ``MetadataQuery``, it can still match. This behavior is
+            appropriate for finding if a specification applies to a Job
+            given metadata.
+
+            If `True`, the orientation of the matching is reversed. Now
+            ``metadata`` matches the ``MetadataQuery`` if ``MetadataQuery``
+            has all the terms defined in ``metadata`` and those terms match.
+            If ``MetadataQuery`` has more terms than ``metadata``, it can
+            still match. This behavior is appropriate for discovering
+            specifications.
 
         Returns
         -------
-        applies : `bool`
-            `True` if this specification applies to a Job's measurement, or
-            `False` otherwise.
+        matched : `bool`
+            `True` if this specification matches, `False` otherwise.
+
+        See also
+        --------
+        lsst.verify.MetadataQuery
         """
-        return self.metadata_query(metadata)
+        return self.metadata_query(metadata, arg_driven=arg_driven)

--- a/python/lsst/verify/spec/base.py
+++ b/python/lsst/verify/spec/base.py
@@ -61,9 +61,9 @@ class Specification(with_metaclass(abc.ABCMeta, JsonSerializationMixin)):
             raise TypeError(message.format(self._name))
 
         if 'metadata_query' in kwargs:
-            self.metadata_query = MetadataQuery(kwargs['metadata_query'])
+            self._metadata_query = MetadataQuery(kwargs['metadata_query'])
         else:
-            self.metadata_query = MetadataQuery()
+            self._metadata_query = MetadataQuery()
 
         if 'tags' in kwargs:
             self.tags = kwargs['tags']
@@ -116,7 +116,7 @@ class Specification(with_metaclass(abc.ABCMeta, JsonSerializationMixin)):
                 'name': str(self.name),
                 'type': self.type,
                 self.type: self._serialize_type(),
-                'metadata_query': self.metadata_query,
+                'metadata_query': self._metadata_query,
                 'tags': self.tags
             }
         )
@@ -171,4 +171,4 @@ class Specification(with_metaclass(abc.ABCMeta, JsonSerializationMixin)):
         --------
         lsst.verify.MetadataQuery
         """
-        return self.metadata_query(metadata, arg_driven=arg_driven)
+        return self._metadata_query(metadata, arg_driven=arg_driven)


### PR DESCRIPTION
This adds a new `required_meta` argument to `SpecificationSet.subset()`:

```rst
        required_metadata : `dict` or `lsst.verify.Metadata`, optional
            If supplied, only specifications that have **all** the terms in
            ``required_metadata`` (and their term values match) are selected.
            This is opposite to the logic of the ``meta`` argument where a
            specification with an empty metadata query is always selected,
            for example.
```

Also adds an 'arg_driven' argument to SpecificationSet.query_metadata and to MetadataQuery.__call__ to enable this query mode rather than the default mode.

Example (run in ipython/notebook):

```
from lsst.verify import SpecificationSet
specs = SpecificationSet.load_metrics_package()
metadata = {'filter_name': 'HSC-R'}
print([str(k) for k in specs.subset(required_meta=metadata).keys()])
```

Output:

```
['validate_drp.PA2_stretch_gri.hsc_r', 'validate_drp.PA1.hsc_stretch_r', 'validate_drp.PA2_minimum_gri.hsc_r', 'validate_drp.PF1_minimum_gri.hsc_r', 'validate_drp.PF1_design_gri.hsc_r', 'validate_drp.PA1.hsc_design_r', 'validate_drp.PA2_design_gri.hsc_r', 'validate_drp.PF1_stretch_gri.hsc_r', 'validate_drp.PA1.hsc_minimum_r']
```