### PR TITLE
DM-9534: Coerce floats to Quantities

### DIFF
--- a/python/lsst/verify/measurement.py
+++ b/python/lsst/verify/measurement.py
@@ -193,8 +193,12 @@ class Measurement(JsonSerializationMixin):
     def quantity(self, q):
         # a quantity can be None or a Quantity
         if not isinstance(q, u.Quantity) and q is not None:
-            message = '{0} is not an astropy.units.Quantity-type'
-            raise TypeError(message.format(q))
+            try:
+                q = q*u.dimensionless_unscaled
+            except (TypeError, ValueError):
+                message = ('{0} cannot be coerced into an '
+                           'astropy.units.dimensionless_unscaled')
+                raise TypeError(message.format(q))
 
         if self.metric is not None and q is not None:
             # check unit consistency

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -198,6 +198,18 @@ class MeasurementTestCase(TestCase):
         measurement.extras['extra1'] = Datum(10. * u.arcmin, 'Extra 1')
         self.assertIn('extra1', measurement.extras)
 
+    def test_quantity_coercion(self):
+        # strings can't be changed into a Quantity
+        with self.assertRaises(TypeError):
+            Measurement('test_metric', quantity='hello')
+        # objects can't be a Quantity
+        with self.assertRaises(TypeError):
+            Measurement('test_metric', quantity=int)
+        m = Measurement('test_metric', quantity=5)
+        self.assertEqual(m.quantity, 5)
+        m = Measurement('test_metric', quantity=5.1)
+        self.assertEqual(m.quantity, 5.1)
+
     def test_str(self):
         metric = 'test.cmodel_mag'
         value = 1235 * u.mag


### PR DESCRIPTION
This implements converting unit-less floats and ints to `Quantities` with unit `dimensionless_unscaled`.  There is a test.
****

- [x] Passes Jenkins CI.
- [x] Documentation is up-to-date.

Preview the docs at: https://pipelines.lsst.io/v/DM-FIXME
