### PR TITLE
DM-13122: Separate the execution environment metadata from the other metadata in the JSON document sent to SQuaSH (dispatch_verify.py)

### DIFF
--- a/python/lsst/verify/bin/dispatchverify.py
+++ b/python/lsst/verify/bin/dispatchverify.py
@@ -287,7 +287,6 @@ def insert_extra_package_metadata(job, config):
 def insert_env_metadata(job, env_name, metadata):
     """Insert environment metadata into the Job.
     """
-
     metadata.update({'env_name': env_name})
     job.meta['env'] = metadata
 

--- a/python/lsst/verify/bin/dispatchverify.py
+++ b/python/lsst/verify/bin/dispatchverify.py
@@ -55,7 +55,7 @@ from __future__ import print_function
 
 # For determining what is documented in Sphinx
 __all__ = ['parse_args', 'main', 'insert_lsstsw_metadata',
-           'insert_extra_package_metadata', 'insert_jenkins_metadata',
+           'insert_extra_package_metadata', 'insert_env_metadata',
            'Configuration']
 
 import argparse
@@ -204,7 +204,8 @@ def main():
     # Add environment variable metadata from the Jenkins CI environment
     if config.env_name == 'jenkins':
         log.info('Inserting Jenkins CI environment metadata.')
-        job = insert_jenkins_metadata(job, config)
+        jenkins_metadata = get_jenkins_env()
+        job = insert_env_metadata(job, 'jenkins', jenkins_metadata)
 
     # Upload job
     if not config.test:
@@ -283,11 +284,13 @@ def insert_extra_package_metadata(job, config):
     return job
 
 
-def insert_jenkins_metadata(job, config):
-    """Insert metadata into the Job from the Jenkins environment.
+def insert_env_metadata(job, env_name, metadata):
+    """Insert environment metadata into the Job.
     """
-    jenkins_metadata = get_jenkins_env()
-    job.meta.update(jenkins_metadata)
+
+    metadata.update({'env_name': env_name})
+    job.meta['env'] = metadata
+
     return job
 
 


### PR DESCRIPTION
- In the job JSON document created by dispatch_verify.py the metadata
from the execution enviroment is now stored separately. That makes it
easier to identify and store the metadata required by SQuaSH and
antecipate the support for multiple execution enviroments as being
designed at https://sqr-009.lsst.io/

More information on https://jira.lsstcorp.org/browse/DM-13122

****
- [ ] Passes Jenkins CI 
- [x] Documentation is up-to-date.
