### PR TITLE
DM-13237: Implement authentication via access token

### DIFF
--- a/python/lsst/verify/job.py
+++ b/python/lsst/verify/job.py
@@ -309,7 +309,7 @@ class Job(JsonSerializationMixin):
             json.dump(self.json, f)
 
     def dispatch(self, api_user=None, api_password=None,
-                 api_url='https://squash.lsst.codes/dashboard/api/',
+                 api_url='https://squash-restful-api.lsst.codes',
                  **kwargs):
         """POST the job to SQUASH, LSST Data Management's metric dashboard.
 
@@ -328,9 +328,12 @@ class Job(JsonSerializationMixin):
         # subset JSON to just the 'job' fields; no metrics and specs
         job_json = {k: full_json_doc[k]
                     for k in ('measurements', 'blobs', 'meta')}
-        squash.post(api_url, 'jobs', json_doc=job_json,
-                    api_user=api_user, api_password=api_password,
-                    **kwargs)
+
+        access_token = squash.get_access_token(api_url, api_user,
+                                               api_password)
+
+        squash.post(api_url, 'job', json_doc=job_json,
+                    access_token=access_token, **kwargs)
 
     def report(self, name=None, spec_tags=None, metric_tags=None):
         """Create a verification report that lists the pass/fail status of

--- a/python/lsst/verify/squash.py
+++ b/python/lsst/verify/squash.py
@@ -160,7 +160,6 @@ def get_access_token(api_url, api_user, api_password, api_auth_endpoint='auth'):
     access_token: `str`
        The access token from the SQUASH API authorization endpoint.
     """
-
     json_doc = {'username': api_user, 'password': api_password}
 
     r = post(api_url, api_auth_endpoint, json_doc)
@@ -171,13 +170,12 @@ def get_access_token(api_url, api_user, api_password, api_auth_endpoint='auth'):
 
 
 def make_authorization_header(access_token):
-    """Make the ``Authorization`` HTTP header assuming a valid
-    access token returned by (`get_access_token`).
+    """Make an ``Authorization`` HTTP header using a SQUASH access token.
 
     Parameters
     ----------
     access_token : `str`
-        Access token returned by (`get_access_token`).
+        Access token returned by `get_access_token`.
 
     Returns
     -------
@@ -206,8 +204,8 @@ def post(api_url, api_endpoint, json_doc=None,
     version : `str`, optional
         API version. The value of `get_default_api_version` is used by default.
     access_token : `str`, optional
-        Access token. Not required when a POST is done to the API authorization
-        endpoint.
+        Access token (see `get_access_token`). Not required when a POST is done
+        to the API authorization endpoint.
 
     Raises
     ------


### PR DESCRIPTION
- New methods `get_access_token()` and `make_authorization_header()`
- Fixed default SQUASH API URL
- Since we reimplemented the SQUASH API, we decided that the
default version is 1.0, more information at DM-8836
- Fixed API endpoint name jobs -> job
- squash.post() now accepts status code 200 (OK) as returned by flask-jwt

