### PR TITLE
DM-14302: More lenient ThresholdSpecification repr test

### DIFF
--- a/tests/test_threshold_specification.py
+++ b/tests/test_threshold_specification.py
@@ -113,10 +113,12 @@ class ThresholdSpecificationTestCase(unittest.TestCase):
         self.assertEqual(s.threshold.value, 5.)
         self.assertEqual(s.threshold.unit, u.mag)
         self.assertEqual(s.operator_str, '<')
-        self.assertEqual(
-            repr(s),
-            "ThresholdSpecification("
-            "Name(spec='design'), <Quantity 5.0 mag>, '<')")
+        # Sanity-check repr
+        self.assertIn('ThresholdSpecification', repr(s))
+        self.assertIn('design', repr(s))
+        self.assertIn('Quantity', repr(s))
+        self.assertIn('mag', repr(s))
+        self.assertIn('5', repr(s))
 
         # Test specification check method
         self.assertTrue(


### PR DESCRIPTION
Doing the string match with a floating point Quantity is fraught — and created an issue for a numpy 1.14 upgrade. This substring matching makes sure the that `ThresholdSpecification.__repr__` is generally providing the right info.

Note we can't test this repr by instantiating the object from the repr string because the Astropy quantity `__repr__` isn't instantiable.

Jenkins run: https://ci.lsst.codes/blue/organizations/jenkins/stack-os-matrix/detail/stack-os-matrix/27902/pipeline