### PR TITLE
[DM-15165] Add new tags for validate_drp metric definition and specifications

### DIFF
--- a/tests/test_specification_set.py
+++ b/tests/test_specification_set.py
@@ -362,7 +362,7 @@ class TestSpecificationSetLoadMetricsPackage(unittest.TestCase):
 
     def test_contains(self):
         self.assertTrue('validate_drp.PA1.design_gri' in self.spec_set)
-        self.assertTrue('validate_drp:cfht_gri/base#base' in self.spec_set)
+        self.assertTrue('validate_drp:cfht_gri/base#cfht' in self.spec_set)
 
 
 class TestSpecificationSetNameSubset(unittest.TestCase):


### PR DESCRIPTION
Small change on tests to reflect new name for a specification partials id.
See also: https://github.com/lsst/verify_metrics/pull/12
****

- [X] Passes Jenkins CI.
- [X] Documentation is up-to-date.

