### PR TITLE
DM-16017: Prototype a metrics-handling Task

### DIFF
--- a/doc/lsst.verify/index.rst
+++ b/doc/lsst.verify/index.rst
@@ -39,4 +39,7 @@ Python API reference
 .. automodapi:: lsst.verify.report
    :no-inheritance-diagram:
 
+.. automodapi:: lsst.verify.compatibility
+   :no-inheritance-diagram:
+
 .. _SQUASH: https://squash.lsst.codes

--- a/python/lsst/verify/__init__.py
+++ b/python/lsst/verify/__init__.py
@@ -43,3 +43,4 @@ from .blobset import *
 from .jobmetadata import *
 from .job import *
 from .output import *
+from .metricTask import *

--- a/python/lsst/verify/compatibility/__init__.py
+++ b/python/lsst/verify/compatibility/__init__.py
@@ -1,0 +1,22 @@
+# This file is part of verify.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from .metricTask import *

--- a/python/lsst/verify/compatibility/__init__.py
+++ b/python/lsst/verify/compatibility/__init__.py
@@ -20,3 +20,4 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from .metricTask import *
+from .metricsControllerTask import *

--- a/python/lsst/verify/compatibility/metricTask.py
+++ b/python/lsst/verify/compatibility/metricTask.py
@@ -1,0 +1,213 @@
+# This file is part of verify.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__all__ = ["MetricTask"]
+
+import abc
+
+import lsst.pex.config
+import lsst.pipe.base as pipeBase
+
+
+class MetricTask(pipeBase.Task, metaclass=abc.ABCMeta):
+    """A base class for tasks that compute exactly one metric from arbitrary
+    input datasets.
+
+    Parameters
+    ----------
+    args
+    kwargs
+        Constructor parameters are the same as for
+        `lsst.pipe.base.PipelineTask`.
+
+    Notes
+    -----
+    In general, both the ``MetricTask``'s metric and its input data are
+    configurable. Metrics may be associated with a data ID at any level of
+    granularity, including repository-wide.
+
+    Like `lsst.pipe.base.PipelineTask`, this class should be customized by
+    overriding one of `run` or `adaptArgsAndRun`. For requirements on these
+    methods that are specific to ``MetricTask``, see `adaptArgsAndRun`.
+
+    .. note::
+        The API is designed to make it easy to convert all ``MetricTasks`` to
+        `~lsst.pipe.base.PipelineTask` later, but this class is *not* a
+        `~lsst.pipe.base.PipelineTask` and does not work with activators,
+        quanta, or `lsst.daf.butler`.
+    """
+
+    # There may be a specialized MetricTaskConfig later, details TBD
+    ConfigClass = lsst.pex.config.Config
+
+    def adaptArgsAndRun(self, inputData, inputDataIds, outputDataId):
+        """Compute a metric from in-memory data.
+
+        Parameters
+        ----------
+        inputData : `dict` from `str` to any
+            Dictionary whose keys are the names of input parameters and values
+            are Python-domain data objects (or lists of objects) retrieved
+            from data butler. Accepting lists of objects is strongly
+            recommended; this allows metrics to vary their granularity up to
+            the granularity of the input data without the need for extensive
+            code changes. Input objects may be `None` to represent
+            missing data.
+        inputDataIds : `dict` from `str` to `list` of dataId
+            Dictionary whose keys are the names of input parameters and values
+            are data IDs (or lists of data IDs) that the task consumes for
+            corresponding dataset type. Data IDs are guaranteed to match data
+            objects in ``inputData``.
+        outputDataId : `dict` from `str` to dataId
+            Dictionary containing a single key, ``"measurement"``, which maps
+            to a single data ID for the measurement. The data ID must have the
+            same granularity as the metric.
+
+        Returns
+        -------
+        struct : `lsst.pipe.base.Struct`
+            A `~lsst.pipe.base.Struct` containing at least the
+            following component:
+
+            - ``measurement``: the value of the metric identified by
+              `getOutputMetricName`, computed from ``inputData``
+              (`lsst.verify.Measurement` or `None`). The measurement is
+              guaranteed to contain not only the value of the metric, but also
+              any mandatory supplementary information.
+
+        Raises
+        ------
+        lsst.verify.MetricComputationError
+            Raised if an algorithmic or system error prevents calculation
+            of the metric. Examples include corrupted input data or
+            unavoidable exceptions raised by analysis code. The
+            `~lsst.verify.MetricComputationError` should be chained to a more
+            specific exception describing the root cause.
+
+            Not having enough data for a metric to be applicable is not an
+            error, and should not trigger this exception.
+
+        Notes
+        -----
+        This implementation calls `run` on the contents of ``inputData``,
+        followed by calling `addStandardMetadata` on the result before
+        returning it. Any subclass that overrides this method must also call
+        `addStandardMetadata` on its measurement before returning it.
+
+        `adaptArgsAndRun` and `run` should assume they take multiple input
+        datasets, regardless of the expected metric granularity. This rule may
+        be broken if it is impossible for more than one copy of a dataset
+        to exist.
+
+        All input data must be treated as optional. This maximizes the
+        ``MetricTask``'s usefulness for incomplete pipeline runs or runs with
+        optional processing steps. If a metric cannot be calculated because
+        the necessary inputs are missing, the ``MetricTask`` must return `None`
+        in place of the measurement.
+
+        Examples
+        --------
+        Consider a metric that characterizes PSF variations across the entire
+        field of view, given processed images. Then, if `run` has the
+        signature ``run(images)``:
+
+        .. code-block:: py
+
+            inputData = {'images': [image1, image2, ...]}
+            inputDataIds = {'images': [{'visit': 42, 'ccd': 1},
+                                       {'visit': 42, 'ccd': 2},
+                                       ...]}
+            outputDataId = {'measurement': {'visit': 42}}
+            result = task.adaptArgsAndRun(
+                inputData, inputDataIds, outputDataId)
+        """
+        result = self.run(**inputData)
+        if result.measurement is not None:
+            self.addStandardMetadata(result.measurement,
+                                     outputDataId["measurement"])
+        return result
+
+    @classmethod
+    @abc.abstractmethod
+    def getInputDatasetTypes(cls, config):
+        """Return input dataset types for this task.
+
+        Parameters
+        ----------
+        config : ``cls.ConfigClass``
+            Configuration for this task.
+
+        Returns
+        -------
+        datasets : `dict` from `str` to `str`
+            Dictionary where the key is the name of the input dataset (must
+            match a parameter to `run`) and the value is the name of its
+            Butler dataset type.
+        """
+
+    @classmethod
+    @abc.abstractmethod
+    def getOutputMetricName(cls, config):
+        """Identify the metric calculated by this ``MetricTask``.
+
+        Parameters
+        ----------
+        config : ``cls.ConfigClass``
+            Configuration for this ``MetricTask``.
+
+        Returns
+        -------
+        metric : `lsst.verify.Name`
+            The name of the metric computed by objects of this class when
+            configured with ``config``.
+        """
+
+    def addStandardMetadata(self, measurement, outputDataId):
+        """Add data ID-specific metadata required for all metrics.
+
+        This method currently does not add any metadata, but may do so
+        in the future.
+
+        Parameters
+        ----------
+        measurement : `lsst.verify.Measurement`
+            The `~lsst.verify.Measurement` that the metadata are added to.
+        outputDataId : ``dataId``
+            The data ID to which the measurement applies, at the appropriate
+            level of granularity.
+
+        Notes
+        -----
+        This method must be called by any subclass that overrides
+        `adaptArgsAndRun`, but should be ignored otherwise. It should not be
+        overridden by subclasses.
+
+        This method is not responsible for shared metadata like the execution
+        environment (which should be added by this ``MetricTask``'s caller),
+        nor for metadata specific to a particular metric (which should be
+        added when the metric is calculated).
+
+        .. warning::
+            This method's signature will change whenever additional data needs
+            to be provided. This is a deliberate restriction to ensure that all
+            subclasses pass in the new data as well.
+        """
+        pass

--- a/python/lsst/verify/compatibility/metricsControllerTask.py
+++ b/python/lsst/verify/compatibility/metricsControllerTask.py
@@ -1,0 +1,433 @@
+# This file is part of verify.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__all__ = ["MetricsControllerConfig", "MetricsControllerTask"]
+
+import traceback
+
+import astropy.units as u
+
+import lsst.pex.config as pexConfig
+import lsst.daf.persistence as dafPersist
+from lsst.pipe.base import Task, Struct
+from lsst.verify import Job, Measurement, Name, MetricComputationError
+from .metricTask import MetricTask
+
+
+class MetricsControllerConfig(pexConfig.Config):
+    """Global, metric-independent options for `MetricsControllerTask`.
+    """
+    jobFileTemplate = pexConfig.Field(
+        dtype=str,
+        doc="A template for the path to which the measurements are "
+        "written. {id} is replaced with a unique index (recommended), "
+        "while {dataId} is replaced with the data ID.",
+        default="metrics{id}.{dataId}.verify.json")
+
+
+class MetricsControllerTask(Task):
+    """A Task for executing a collection of
+    `lsst.verify.compatibility.MetricTask` objects.
+
+    This class handles Butler input of datasets needed by metrics, as well as
+    persistence of the resulting measurements.
+
+    Notes
+    -----
+    ``MetricsControllerTask`` is a stand-in for functionality provided by the
+    Gen 3 Tasks framework. It will become redundant once we fully adopt
+    that framework.
+
+    Because ``MetricsControllerTask`` cannot support the full functionality of
+    the Gen 3 framework, it places several restrictions on its metrics:
+        * no ``MetricTask`` may depend on the output of another ``MetricTask``
+        * the granularity of the metrics is determined by the inputs to
+          ``runDataRefs``; configuration information specifying a different
+          granularity is allowed but is ignored
+
+    Multiple instances of ``MetricsControllerTask`` are allowed. The
+    recommended way to handle metrics of different granularities is to group
+    metrics of the same granularity under a ``MetricsControllerTask``
+    configured for that granularity.
+    """
+
+    _DefaultName = "metricsController"
+    ConfigClass = MetricsControllerConfig
+
+    measurers = []
+    """The tasks to be executed by this object (iterable of
+    `lsst.verify.compatibility.MetricTask`).
+    """
+
+    # TODO: remove this method in DM-16535
+    def _makeTimingTask(self, target, metric):
+        """Create a `~lsst.verify.compatibility.MetricTask` that can time
+        a specific method.
+
+        Parameters
+        ----------
+        target : `str`
+            the method to time, optionally prefixed by one or more tasks in
+            the format of `lsst.pipe.base.Task.getFullMetadata()`. All
+            matching methods are counted by the task.
+        metric : `str`
+            the fully qualified name of the metric to contain the
+            timing information
+
+        Returns
+        -------
+        task : `TimingMetricTask`
+            a ``MetricTask`` that times ``target`` and stores the information
+            in ``metric``. It assumes ``target`` is called as part of
+            `lsst.ap.pipe.ApPipeTask`.
+        """
+        config = TimingMetricTask.ConfigClass()
+        config.metadataDataset = "apPipe_metadata"
+        config.target = target
+        config.metric = metric
+        return TimingMetricTask(config=config)
+
+    def __init__(self, config=None, **kwargs):
+        super().__init__(config=config, **kwargs)
+
+        # TODO: generalize in DM-16535
+        self.measurers = [
+            self._makeTimingTask("apPipe.runDataRef", "ap_pipe.ApPipeTime"),
+            self._makeTimingTask("apPipe:ccdProcessor.runDataRef",
+                                 "pipe_tasks.ProcessCcdTime"),
+            self._makeTimingTask("apPipe:ccdProcessor:isr.runDataRef",
+                                 "ip_isr.IsrTime"),
+            self._makeTimingTask("apPipe:ccdProcessor:charImage.runDataRef",
+                                 "pipe_tasks.CharacterizeImageTime"),
+            self._makeTimingTask("apPipe:ccdProcessor:calibrate.runDataRef",
+                                 "pipe_tasks.CalibrateTime"),
+            self._makeTimingTask("apPipe:differencer.runDataRef",
+                                 "pipe_tasks.ImageDifferenceTime"),
+            self._makeTimingTask("apPipe:differencer:register.run",
+                                 "pipe_tasks.RegisterImageTime"),
+            self._makeTimingTask("apPipe:differencer:measurement.run",
+                                 "ip_diffim.DipoleFitTime"),
+            self._makeTimingTask("apPipe:associator.run",
+                                 "ap_association.AssociationTime"),
+        ]
+
+    @staticmethod
+    def _getInstrument(dataref):
+        """Extract the instrument name from a Butler repo.
+
+        Returns
+        -------
+        instrument : `str`
+            The canonical name of the instrument, in all uppercase form.
+        """
+        camera = dataref.get('camera')
+        instrument = camera.getName()
+        return instrument.upper()
+
+    def _computeSingleMeasurement(self, job, metricTask, dataref):
+        """Call a single metric task on a single dataref.
+
+        This method adds a single measurement to ``job``, as specified by
+        ``metricTask``.
+
+        Parameters
+        ----------
+        job : `lsst.verify.Job`
+            A Job object in which to store the new measurement. Must not
+            already contain a measurement for
+            ``metricTask.getOutputMetricName()``.
+        metricTask : `lsst.verify.compatibility.MetricTask`
+            The code for computing the measurement.
+        dataref : `lsst.daf.persistence.ButlerDataRef`
+            The repository and data ID to analyze. The data ID may be
+            incomplete, but must have the granularity of the desired metric.
+
+        Notes
+        -----
+        If measurement calculation fails, this method logs an error and leaves
+        ``job`` unchanged.
+        """
+        self.log.debug("Running %s on %r", type(metricTask), dataref)
+        inputTypes = metricTask.getInputDatasetTypes(metricTask.config)
+        inputData = {}
+        inputDataIds = {}
+        for param, dataType in inputTypes.items():
+            inputRefs = dafPersist.searchDataRefs(
+                dataref.getButler(), dataType, dataId=dataref.dataId)
+            inputData[param] = [ref.get() for ref in inputRefs]
+            inputDataIds[param] = [ref.dataId for ref in inputRefs]
+
+        outputDataIds = {"measurement": dataref.dataId}
+        try:
+            result = metricTask.adaptArgsAndRun(inputData, inputDataIds,
+                                                outputDataIds)
+            value = result.measurement
+            if value is not None:
+                job.measurements.insert(value)
+        except MetricComputationError:
+            # Apparently lsst.log doesn't have built-in exception support?
+            self.log.error("Measurement of %r failed on %s->%s\n%s",
+                           metricTask, inputDataIds, outputDataIds,
+                           traceback.format_exc())
+
+    def runDataRefs(self, datarefs):
+        """Call all registered metric tasks on each dataref.
+
+        This method loads all datasets required to compute a particular
+        metric, and persists the metrics as one or more `lsst.verify.Job`
+        objects.
+
+        Parameters
+        ----------
+        datarefs : `list` of `lsst.daf.persistence.ButlerDataRef`
+            The data to measure. Datarefs may be complete or partial; each
+            generates a measurement at the same granularity (e.g., a
+            dataref with only ``"visit"`` specified generates visit-level
+            measurements).
+
+        Returns
+        -------
+        struct : `lsst.pipe.base.Struct`
+            A `~lsst.pipe.base.Struct` containing the following component:
+
+            - ``jobs`` : a list of collections of measurements (`list` of
+              `lsst.verify.Job`). Each job in the list contains the
+              measurement(s) for the corresponding dataref, and each job has
+              at most one measurement for each element in `self.measurers`. A
+              particular measurement is omitted if it could not be created.
+
+        Notes
+        -----
+        Some objects may be persisted, or incorrectly persisted, in the event
+        of an exception.
+        """
+        jobs = []
+        index = 0
+        for dataref in datarefs:
+            job = Job.load_metrics_package()
+            try:
+                # TODO: generalize this in DM-16642
+                job.meta['instrument'] = \
+                    MetricsControllerTask._getInstrument(dataref)
+                job.meta.update(dataref.dataId)
+
+                for task in self.measurers:
+                    self._computeSingleMeasurement(job, task, dataref)
+            finally:
+                jobFile = self._getJobFilePath(index, dataref.dataId)
+                self.log.info("Persisting metrics to %s...", jobFile)
+                # This call order maximizes the chance that job gets
+                # written, and to a unique file
+                index += 1
+                job.write(jobFile)
+                jobs.append(job)
+
+        return Struct(jobs=jobs)
+
+    def _getJobFilePath(self, index, dataId):
+        """Generate an output file for a Job.
+
+        Parameters
+        ----------
+        index : `int`
+            A unique integer across all Jobs created by this task.
+        dataId : `lsst.daf.persistence.DataId`
+            The identifier of all metrics in the Job to be persisted.
+        """
+        # Construct a relatively OS-friendly string (i.e., no quotes or {})
+        idString = " ".join("%s=%s" % (key, dataId[key]) for key in dataId)
+        return self.config.jobFileTemplate.format(id=index, dataId=idString)
+
+
+# A verbatim copy of lsst.ap.verify.measurements.profiling.TimingMetricTask,
+# to keep MetricsControllerTask from temporarily depending on ap_verify.
+# TODO: remove all code below this point in DM-16535
+
+
+class TimingMetricConfig(MetricTask.ConfigClass):
+    """Information that distinguishes one timing metric from another.
+    """
+    # It would be more user-friendly to identify the top-level task and call
+    # CmdLineTask._getMetadataName, but doing so bypasses the public API and
+    # requires reconstruction of the full task just in case the dataset is
+    # config-dependent.
+    metadataDataset = pexConfig.Field(
+        dtype=str,
+        doc="The dataset type of the timed top-level task's metadata, "
+            "such as 'processCcd_metadata'.")
+    target = pexConfig.Field(
+        dtype=str,
+        doc="The method to time, optionally prefixed by one or more tasks "
+            "in the format of `lsst.pipe.base.Task.getFullMetadata()`. "
+            "All matching methods will be counted.")
+    metric = pexConfig.Field(
+        dtype=str,
+        doc="The fully qualified name of the metric to contain the "
+            "timing information.")
+
+
+class TimingMetricTask(MetricTask):
+    """A Task that measures a timing metric using metadata produced by the
+    `lsst.pipe.base.timeMethod` decorator.
+
+    Parameters
+    ----------
+    args
+    kwargs
+        Constructor parameters are the same as for
+        `lsst.verify.compatibility.MetricTask`.
+    """
+
+    ConfigClass = TimingMetricConfig
+    _DefaultName = "timingMetric"
+
+    @classmethod
+    def _getInputMetadataKeyRoot(cls, config):
+        """A search string for the metadata.
+
+        The string must contain the name of the target method, optionally
+        prefixed by one or more tasks in the format of
+        `lsst.pipe.base.Task.getFullMetadata()`. It should be as short as
+        possible to avoid making assumptions about what subtasks are
+        configured. However, if multiple tasks and methods match the string,
+        they will be assumed to all be relevant to the metric.
+
+        Parameters
+        ----------
+        config : ``cls.ConfigClass``
+            Configuration for this task.
+
+        Returns
+        -------
+        keyRoot : `str`
+            A string identifying the class(es) and method(s) for this task.
+        """
+        return config.target
+
+    @staticmethod
+    def _searchMetadataKeys(metadata, keyFragment):
+        """Metadata search for partial keys.
+
+        Parameters
+        ----------
+        metadata : `lsst.daf.base.PropertySet`
+            A metadata object with task-qualified keys as returned by
+            `lsst.pipe.base.Task.getFullMetadata()`.
+        keyFragment : `str`
+            A substring for a full metadata key.
+
+        Returns
+        -------
+        keys : `set` of `str`
+            All keys in ``metadata`` that have ``keyFragment`` as a substring.
+        """
+        keys = metadata.paramNames(topLevelOnly=False)
+        return {key for key in keys if keyFragment in key}
+
+    def run(self, metadata):
+        """Compute a wall-clock measurement from metadata provided by
+        `lsst.pipe.base.timeMethod`.
+
+        The method shall return no metric if any element of ``metadata`` is
+        ``None``, on the grounds that if a task run was aborted without writing
+        metadata, then any timing measurement wouldn't be comparable to other
+        results anyway. It will also return no metric if no timing information
+        was provided by any of the metadata.
+
+        Parameters
+        ----------
+        metadata : iterable of `lsst.daf.base.PropertySet`
+            A collection of metadata objects, one for each unit of science
+            processing to be incorporated into this metric. Its elements
+            may be `None` to represent missing data.
+
+        Returns
+        -------
+        result : `lsst.pipe.base.Struct`
+            A Struct containing at least the following component:
+
+            - ``measurement``: the total running time of the target method
+                               across all elements of ``metadata``
+                               (`lsst.verify.Measurement` or `None`)
+
+        Raises
+        ------
+        MetricComputationError
+            Raised if any of the timing metadata are invalid.
+        """
+        keyBase = self._getInputMetadataKeyRoot(self.config)
+        endBase = keyBase + "EndCpuTime"
+
+        # some timings are indistinguishable from 0,
+        # so don't test totalTime > 0
+        timingFound = False
+        totalTime = 0.0
+        for singleMetadata in metadata:
+            if singleMetadata is not None:
+                matchingKeys = TimingMetricTask._searchMetadataKeys(
+                    singleMetadata, endBase)
+                for endKey in matchingKeys:
+                    startKey = endKey.replace("EndCpuTime", "StartCpuTime")
+                    try:
+                        # startKey not guaranteed to exist
+                        start, end = (singleMetadata.getAsDouble(key)
+                                      for key in (startKey, endKey))
+                    except (LookupError, TypeError) as e:
+                        raise MetricComputationError("Invalid metadata") \
+                            from e
+                    totalTime += end - start
+                    timingFound = True
+            else:
+                self.log.warn(
+                    "At least one run did not write metadata; aborting.")
+                return Struct(measurement=None)
+
+        if timingFound:
+            meas = Measurement(self.getOutputMetricName(self.config),
+                               totalTime * u.second)
+            meas.notes['estimator'] = 'pipe.base.timeMethod'
+        else:
+            self.log.info(
+                "Nothing to do: no timing information for %s found.",
+                keyBase)
+            meas = None
+        return Struct(measurement=meas)
+
+    @classmethod
+    def getInputDatasetTypes(cls, config):
+        """Return input dataset types for this task.
+
+        Parameters
+        ----------
+        config : ``cls.ConfigClass``
+            Configuration for this task.
+
+        Returns
+        -------
+        metadata : `dict` from `str` to `str`
+            Dictionary from ``"metadata"`` to the dataset type of
+            the target task's metadata.
+        """
+        return {'metadata': config.metadataDataset}
+
+    @classmethod
+    def getOutputMetricName(cls, config):
+        return Name(config.metric)

--- a/python/lsst/verify/compatibility/testUtils.py
+++ b/python/lsst/verify/compatibility/testUtils.py
@@ -1,0 +1,116 @@
+#
+# This file is part of verify.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+__all__ = ["MetricTaskTestCase"]
+
+import unittest.mock
+import inspect
+
+import lsst.utils.tests
+
+from lsst.pipe.base import Struct
+from lsst.verify import Measurement
+
+
+class MetricTaskTestCase(lsst.utils.tests.TestCase):
+    """Unit test base class for tests of `compatibility.MetricTask`.
+
+    This class provides tests of the generic ``MetricTask`` API. Subclasses
+    must override `taskFactory`, and may add extra tests for class-specific
+    functionality. If subclasses override `setUp`, they must call
+    `MetricTaskTestCase.setUp`.
+    """
+
+    # For some reason, setUp for the test cases defined in MetricTaskTestCase
+    # calls the wrong factory if you make it a classmethod
+    taskFactory = None
+    """A nullary callable that constructs the `compatibility.MetricTask`
+    to be tested.
+
+    If a concrete task's constructor satisfies the requirements, its type
+    object may be used as the factory.
+    """
+
+    task = None
+    """The ``MetricTask`` being tested by this object (`compatibility.MetricTask`).
+
+    This attribute is initialized automatically.
+    """
+
+    taskClass = None
+    """The type of `task` (`compatibility.MetricTask`-type).
+
+    This attribute is initialized automatically.
+    """
+
+    def setUp(self):
+        """Setup common to all MetricTask tests.
+
+        Notes
+        -----
+        This implementation calls `taskFactory`, then initializes `task`
+        and `taskClass`.
+        """
+        self.task = self.taskFactory()
+        self.taskClass = type(self.task)
+
+    # Implementation classes will override run or adaptArgsAndRun. Can't
+    # implement most tests if they're mocked, risk excessive runtime if
+    # they aren't.
+
+    def testInputDatasetTypesKeys(self):
+        defaultInputs = self.taskClass.getInputDatasetTypes(self.task.config)
+        runParams = inspect.signature(self.taskClass.run).parameters
+
+        # Only way to check if run has been overridden?
+        if runParams.keys() != ['kwargs']:
+            self.assertSetEqual(
+                set(defaultInputs.keys()).union({'self'}),
+                set(runParams.keys()).union({'self'}),
+                "getInputDatasetTypes keys do not match run parameters")
+
+    def testAddStandardMetadata(self):
+        measurement = Measurement('foo.bar', 0.0)
+        dataId = {'tract': 42, 'patch': 3, 'filter': 'Ic'}
+        self.task.addStandardMetadata(measurement, dataId)
+        # Nothing to test until addStandardMetadata adds something
+
+    def testCallAddStandardMetadata(self):
+        dummy = Measurement('foo.bar', 0.0)
+        with unittest.mock.patch.multiple(
+                self.taskClass, autospec=True,
+                run=unittest.mock.DEFAULT,
+                addStandardMetadata=unittest.mock.DEFAULT) as mockDict:
+            mockDict['run'].return_value = Struct(measurement=dummy)
+
+            inputTypes = self.taskClass.getInputDatasetTypes(self.task.config)
+            inputParams = inputTypes.keys()
+            # Probably won't satisfy all adaptArgsAndRun specs,
+            # but hopefully works with most of them
+            dataId = {}
+            result = self.task.adaptArgsAndRun(
+                {key: [None] for key in inputParams},
+                {key: [dataId] for key in inputParams},
+                {'measurement': {}})
+            mockDict['addStandardMetadata'].assert_called_once_with(
+                self.task, result.measurement, dataId)

--- a/python/lsst/verify/metricTask.py
+++ b/python/lsst/verify/metricTask.py
@@ -1,0 +1,37 @@
+# This file is part of project_name.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+__all__ = ["MetricComputationError"]
+
+
+class MetricComputationError(RuntimeError):
+    """This class represents unresolvable errors in computing a metric.
+
+    `compatibility.MetricTask` raises ``MetricComputationError`` instead of
+    other data- or processing-related exceptions to let code that calls a mix
+    of data processing and metric tasks distinguish between the two.
+    Therefore, most ``MetricComputationError`` instances should be chained to
+    another exception representing the underlying problem.
+    """
+    pass
+
+# TODO: implement MetricTask once PipelineTask is ready for general use

--- a/tests/test_metricsController.py
+++ b/tests/test_metricsController.py
@@ -1,0 +1,193 @@
+# This file is part of verify.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import unittest.mock
+
+import astropy.units as u
+from astropy.tests.helper import assert_quantity_allclose
+
+import lsst.utils.tests
+from lsst.daf.persistence import ButlerDataRef
+from lsst.afw.cameraGeom import Camera
+from lsst.pipe.base import Struct
+from lsst.verify import Job, MetricComputationError
+from lsst.verify.compatibility import MetricTask, MetricsControllerTask
+
+
+def _metricName():
+    """The metric to be hypothetically measured using the mock task.
+    """
+    return "misc_tasks.FancyMetric"
+
+
+# TODO: can be replaced with a vanilla mock after DM-16642
+def _makeMockDataref(_datasetType, dataId=None):
+    """A dataref-like object that returns a mock camera.
+    """
+    camera = unittest.mock.NonCallableMock(
+        Camera, autospec=True, **{"getName.return_value": "fancyCam"})
+    return unittest.mock.NonCallableMock(
+        ButlerDataRef, autospec=True, **{"get.return_value": camera},
+        dataId=dataId)
+
+
+def _butlerQuery(_butler, datasetType, _level="", dataId=None):
+    """Return a number of datarefs corresponding to a (partial) dataId.
+    """
+    dataref = _makeMockDataref(datasetType)
+
+    # Simulate a dataset of 3 visits and 2 CCDs
+    nRuns = 1
+    if "visit" not in dataId:
+        nRuns *= 3
+    if "ccd" not in dataId:
+        nRuns *= 2
+    return [dataref] * nRuns
+
+
+@unittest.mock.patch.object(Job, "load_metrics_package", side_effect=Job)
+@unittest.mock.patch("lsst.daf.persistence.searchDataRefs", autospec=True,
+                     side_effect=_butlerQuery)
+@unittest.mock.patch("lsst.verify.Job.write", autospec=True)
+class MetricsControllerTestSuite(lsst.utils.tests.TestCase):
+
+    def setUp(self):
+        self.task = MetricsControllerTask()
+
+        self.metricTask = unittest.mock.create_autospec(
+            MetricTask, instance=True)
+        self.task.measurers = [self.metricTask]
+        # For some reason can't set these in create_autospec call
+        self.metricTask.config = None
+        self.metricTask.getInputDatasetTypes.return_value = \
+            {"input": "metadata"}
+
+        def returnMeasurement(inputData, _inputDataIds, _outputDataIds):
+            nData = len(inputData["input"])
+            return Struct(measurement=lsst.verify.Measurement(
+                _metricName(), nData * u.second))
+        self.metricTask.adaptArgsAndRun.side_effect = returnMeasurement
+
+    def _checkMetric(self, mockWriter, datarefs, unitsOfWork):
+        """Standardized test battery for running a timing metric.
+
+        Parameters
+        ----------
+        mockWriter : `unittest.mock.CallableMock`
+            A queriable placeholder for `lsst.verify.Job.write`.
+        datarefs : `list` of `lsst.daf.persistence.ButlerDataRef`
+            The inputs to `MetricsControllerTask.runDataRefs`.
+        unitsOfWork : `list` of `int`
+            The number of science pipeline units of work (i.e., CCD-visit
+            pairs) that should be combined to make a metric for each element
+            of ``datarefs``.
+        """
+        if len(datarefs) != len(unitsOfWork):
+            raise ValueError("Test requires matching datarefs "
+                             "and unitsOfWork")
+
+        jobs = self.task.runDataRefs(datarefs).jobs
+        self.assertEqual(len(jobs), len(datarefs))
+        for job, dataref, nTimings in zip(jobs, datarefs, unitsOfWork):
+            self.assertEqual(len(job.measurements), 1)
+            assert_quantity_allclose(
+                job.measurements[_metricName()].quantity,
+                float(nTimings) * u.second)
+            self.assertEqual(job.meta["instrument"], "FANCYCAM")
+            for key in dataref.dataId:
+                self.assertEqual(job.meta[key], dataref.dataId[key])
+
+        # Exact arguments to Job.write are implementation detail, don't test
+        if not jobs:
+            mockWriter.assert_not_called()
+        elif len(jobs) == 1:
+            mockWriter.assert_called_once()
+        else:
+            mockWriter.assert_called()
+
+    def testCcdGrainedMetric(self, mockWriter, _mockButler,
+                             _mockMetricsLoader):
+        dataId = {"visit": 42, "ccd": 101, "filter": "k"}
+        datarefs = [_makeMockDataref("calexp", dataId=dataId)]
+        self._checkMetric(mockWriter, datarefs, unitsOfWork=[1])
+
+    def testVisitGrainedMetric(self, mockWriter, _mockButler,
+                               _mockMetricsLoader):
+        dataId = {"visit": 42, "filter": "k"}
+        datarefs = [_makeMockDataref("calexp", dataId=dataId)]
+        self._checkMetric(mockWriter, datarefs, unitsOfWork=[2])
+
+    def testDatasetGrainedMetric(self, mockWriter, _mockButler,
+                                 _mockMetricsLoader):
+        dataId = {}
+        datarefs = [_makeMockDataref("calexp", dataId=dataId)]
+        self._checkMetric(mockWriter, datarefs, unitsOfWork=[6])
+
+    def testMultipleMetrics(self, mockWriter, _mockButler,
+                            _mockMetricsLoader):
+        dataIds = [{"visit": 42, "ccd": 101, "filter": "k"},
+                   {"visit": 42, "ccd": 102, "filter": "k"}]
+        datarefs = [_makeMockDataref("calexp", dataId=dataId)
+                    for dataId in dataIds]
+        self._checkMetric(mockWriter, datarefs,
+                          unitsOfWork=[1] * len(dataIds))
+
+    def testInvalidMetricSegregation(self, _mockWriter, _mockButler,
+                                     _mockMetricsLoader):
+        self.metricTask.adaptArgsAndRun.side_effect = (
+            MetricComputationError, unittest.mock.DEFAULT)
+        self.metricTask.adaptArgsAndRun.return_value = Struct(
+            measurement=lsst.verify.Measurement(_metricName(),
+                                                1.0 * u.second))
+
+        dataIds = [{"visit": 42, "ccd": 101, "filter": "k"},
+                   {"visit": 42, "ccd": 102, "filter": "k"}]
+        datarefs = [_makeMockDataref("calexp", dataId=dataId)
+                    for dataId in dataIds]
+
+        jobs = self.task.runDataRefs(datarefs).jobs
+        self.assertEqual(len(jobs), len(datarefs))
+
+        self.assertEqual(len(jobs[0].measurements), 0)
+        for job in jobs:
+            self.assertEqual(job.meta["instrument"], "FANCYCAM")
+        for job in jobs[1:]:
+            self.assertEqual(len(job.measurements), 1)
+            assert_quantity_allclose(
+                job.measurements[_metricName()].quantity,
+                float(1.0) * u.second)
+
+    def testNoData(self, mockWriter, _mockButler, _mockMetricsLoader):
+        datarefs = []
+        self._checkMetric(mockWriter, datarefs, unitsOfWork=[])
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/ups/verify.table
+++ b/ups/verify.table
@@ -8,6 +8,8 @@ setupRequired(utils)
 setupRequired(pex_exceptions)
 setupRequired(log)
 setupRequired(pytest_flake8)
+setupRequired(pex_config)
+setupRequired(pipe_base)
 
 # verify_metrics is the default metrics repo and is used in tests
 setupRequired(verify_metrics)


### PR DESCRIPTION
This PR adds prototype implementations of the `MetricTask` and `MetricsControllerTask` classes described by [DMTN-098](https://dmtn-098.lsst.io/v/DM-16017/). The implementation of `MetricsControllerTask` currently relies on a hard-coded copy of `ap.verify.measurements.profiling.TimingMetricTask` (see lsst/ap_verify#55 for the "real" version). Its removal is ticketed as [DM-16535](https://jira.lsstcorp.org/browse/DM-16535); setting up a proper configuration system for `MetricsControllerTask` was deemed too challenging for an initial prototype.

This PR adds API documentation but no package-level documentation. The current code is not suitable for general use, so I would prefer to defer writing package-level docs until `MetricsControllerTask` is closer to its intended form.