### PR TITLE
DM-16822: Use pipe.base.*DatasetConfig in MetricTask configs

### DIFF
--- a/python/lsst/verify/compatibility/metricTask.py
+++ b/python/lsst/verify/compatibility/metricTask.py
@@ -45,8 +45,10 @@ class MetricTask(pipeBase.Task, metaclass=abc.ABCMeta):
     granularity, including repository-wide.
 
     Like `lsst.pipe.base.PipelineTask`, this class should be customized by
-    overriding one of `run` or `adaptArgsAndRun`. For requirements on these
-    methods that are specific to ``MetricTask``, see `adaptArgsAndRun`.
+    overriding one of `run` or `adaptArgsAndRun` and by providing an
+    `~lsst.pipe.base.InputDatasetField` for each parameter of `run`. For
+    requirements on these methods that are specific to ``MetricTask``, see
+    `adaptArgsAndRun`.
 
     .. note::
         The API is designed to make it easy to convert all ``MetricTasks`` to
@@ -55,7 +57,8 @@ class MetricTask(pipeBase.Task, metaclass=abc.ABCMeta):
         quanta, or `lsst.daf.butler`.
     """
 
-    # There may be a specialized MetricTaskConfig later, details TBD
+    # TODO: create a specialized MetricTaskConfig once metrics have
+    # Butler datasets
     ConfigClass = lsst.pex.config.Config
 
     def adaptArgsAndRun(self, inputData, inputDataIds, outputDataId):
@@ -146,7 +149,6 @@ class MetricTask(pipeBase.Task, metaclass=abc.ABCMeta):
         return result
 
     @classmethod
-    @abc.abstractmethod
     def getInputDatasetTypes(cls, config):
         """Return input dataset types for this task.
 
@@ -161,7 +163,18 @@ class MetricTask(pipeBase.Task, metaclass=abc.ABCMeta):
             Dictionary where the key is the name of the input dataset (must
             match a parameter to `run`) and the value is the name of its
             Butler dataset type.
+
+        Notes
+        -----
+        The default implementation searches ``config`` for
+        `~lsst.pipe.base.InputDatasetConfig` fields, much like
+        `lsst.pipe.base.PipelineTask.getInputDatasetTypes` does.
         """
+        datasets = {}
+        for key, value in config.items():
+            if isinstance(value, lsst.pipe.base.InputDatasetConfig):
+                datasets[key] = value.name
+        return datasets
 
     @classmethod
     @abc.abstractmethod

--- a/python/lsst/verify/compatibility/metricTask.py
+++ b/python/lsst/verify/compatibility/metricTask.py
@@ -33,8 +33,8 @@ class MetricTask(pipeBase.Task, metaclass=abc.ABCMeta):
 
     Parameters
     ----------
-    args
-    kwargs
+    *args
+    **kwargs
         Constructor parameters are the same as for
         `lsst.pipe.base.PipelineTask`.
 

--- a/python/lsst/verify/metricTask.py
+++ b/python/lsst/verify/metricTask.py
@@ -1,4 +1,4 @@
-# This file is part of project_name.
+# This file is part of verify.
 #
 # Developed for the LSST Data Management System.
 # This product includes software developed by the LSST Project


### PR DESCRIPTION
This PR modifies the Gen 2 class `compatibility.MetricTask` to use `InputDatasetConfig` to specify its inputs. This change will simplify the transition to the Gen 3 `MetricTask`, once it exists. I'm not sure if the documentation makes it clear enough that `InputDatasetConfig` is the primary way for `MetricTask` to describe its inputs.

While the original ticket also asked to use `OutputDatasetConfig`, this can't be done until Butler support for `Measurement` is available.