### PR TITLE
DM-16535: Implement MetricRegistry

### DIFF
--- a/doc/lsst.verify/index.rst
+++ b/doc/lsst.verify/index.rst
@@ -14,6 +14,8 @@ Measurements made through `lsst.verify` can be uploaded to LSST's SQUASH_ monito
 
    `SQR-019: LSST Verification Framework API Demonstration <https://sqr-019.lsst.io>`_.
 
+.. _lsst.verify-using:
+
 Using lsst.verify
 =================
 
@@ -21,6 +23,39 @@ Using lsst.verify
    :maxdepth: 1
 
    inspect_job
+
+.. _lsst.verify-command-line-taskref:
+
+Task reference
+==============
+
+.. .. _lsst.verify-command-line-tasks:
+..
+.. Command-line tasks
+.. ------------------
+..
+.. .. lsst-cmdlinetasks::
+..    :root: lsst.verify
+
+.. _lsst.verify-tasks:
+
+Tasks
+-----
+
+.. lsst-tasks::
+   :root: lsst.verify
+   :toctree: tasks
+
+.. .. _lsst.verify-configs:
+..
+.. Configurations
+.. --------------
+..
+.. .. lsst-configs::
+..    :root: lsst.verify
+..    :toctree: configs
+
+.. _lsst.verify-pyapi:
 
 Python API reference
 ====================

--- a/doc/lsst.verify/tasks/lsst.verify.compatibility.MetricTask.rst
+++ b/doc/lsst.verify/tasks/lsst.verify.compatibility.MetricTask.rst
@@ -1,0 +1,57 @@
+.. lsst-task-topic:: lsst.verify.compatibility.MetricTask
+
+.. currentmodule:: lsst.verify.compatibility
+
+######################################
+MetricTask (lsst.verify.compatibility)
+######################################
+
+``MetricTask`` is a base class for generating `lsst.verify.Measurement` given input data.
+Each ``MetricTask`` class accepts specific type(s) of datasets and produces measurements for a specific metric or family of metrics.
+
+While its API mirrors that of `~lsst.pipe.base.PipelineTask`, this version of ``MetricTask`` is designed to be used with the Gen 2 framework.
+
+.. _lsst.verify.compatibility.MetricTask-api:
+
+Python API summary
+==================
+
+.. lsst-task-api-summary:: lsst.verify.compatibility.MetricTask
+
+.. _lsst.verify.compatibility.MetricTask-subtasks:
+
+Retargetable subtasks
+=====================
+
+.. lsst-task-config-subtasks:: lsst.verify.compatibility.MetricTask
+
+.. _lsst.verify.compatibility.MetricTask-configs:
+
+Configuration fields
+====================
+
+.. lsst-task-config-fields:: lsst.verify.compatibility.MetricTask
+
+.. _lsst.verify.compatibility.MetricTask-indepth:
+
+In Depth
+========
+
+.. _lsst.verify.compatibility.MetricTask-indepth-subclassing:
+
+Subclassing
+-----------
+
+``MetricTask`` is primarily customized using the `~MetricTask.run` or `~MetricTask.adaptArgsAndRun` methods.
+Each subclass must also implement the `~MetricTask.getOutputMetricName` method.
+
+The task config should use `lsst.pipe.base.InputDatasetConfig` to identify input datasets as if it were a `~lsst.pipe.base.PipelineTask`.
+Only the ``name`` field is used in a Gen 2 context, but use of `~lsst.pipe.base.InputDatasetConfig` is expected to simplify the transition to Gen 3.
+
+.. _lsst.verify.compatibility.MetricTask-indepth-register:
+
+Registration
+------------
+
+The most common way to run ``MetricTask`` is as plugins to `~lsst.verify.compatibility.MetricsControllerTask`.
+Most ``MetricTask`` classes should use the `register` decorator to assign a plugin name.

--- a/doc/lsst.verify/tasks/lsst.verify.compatibility.MetricTask.rst
+++ b/doc/lsst.verify/tasks/lsst.verify.compatibility.MetricTask.rst
@@ -53,5 +53,5 @@ Only the ``name`` field is used in a Gen 2 context, but use of `~lsst.pipe.base.
 Registration
 ------------
 
-The most common way to run ``MetricTask`` is as plugins to `~lsst.verify.compatibility.MetricsControllerTask`.
+The most common way to run ``MetricTask`` is as plugins to :lsst-task:`~lsst.verify.compatibility.MetricsControllerTask`.
 Most ``MetricTask`` classes should use the `register` decorator to assign a plugin name.

--- a/doc/lsst.verify/tasks/lsst.verify.compatibility.MetricTask.rst
+++ b/doc/lsst.verify/tasks/lsst.verify.compatibility.MetricTask.rst
@@ -55,3 +55,6 @@ Registration
 
 The most common way to run ``MetricTask`` is as plugins to :lsst-task:`~lsst.verify.compatibility.MetricsControllerTask`.
 Most ``MetricTask`` classes should use the `register` decorator to assign a plugin name.
+
+Because of implementation limitations, each registered name may appear at most once in `MetricsControllerConfig`.
+If you expect to need multiple instances of the same ``MetricTask`` class (typically when the same class can compute multiple metrics), it must have the `registerMultiple` decorator instead.

--- a/doc/lsst.verify/tasks/lsst.verify.compatibility.MetricsControllerTask.rst
+++ b/doc/lsst.verify/tasks/lsst.verify.compatibility.MetricsControllerTask.rst
@@ -57,6 +57,8 @@ Each :lsst-task:`~lsst.verify.compatibility.MetricTask` in a ``MetricsController
 Examples
 ========
 
+Typically, a user of ``MetricsControllerTask`` will configure it with tasks that have `register` decorator:
+
 .. code-block:: py
 
    from lsst.verify.compatibility import register, \
@@ -84,3 +86,24 @@ Examples
                for ccd in range(1, 101)]
    struct = task.runDataRefs(datarefs)
    assert len(struct.jobs) == len(datarefs)
+
+A :lsst-task:`~lsst.verify.compatibility.MetricTask` must have the `registerMultiple` decorator to be used multiple times:
+
+.. code-block:: py
+
+   from lsst.verify.compatibility import registerMultiple, MetricTask, MetricsControllerTask
+
+   @registerMultiple("common")
+   class CommonMetric(MetricTask):
+       ...
+
+   config = MetricsControllerTask.ConfigClass()
+   config.measurers = ["common"]
+   config.measurers["common"].configs["case1"] = CommonMetric.ConfigClass()
+   config.measurers["common"].configs["case1"].metric = "misc_tasks.Case1Metric"
+   config.measurers["common"].configs["case2"] = CommonMetric.ConfigClass()
+   config.measurers["common"].configs["case2"].metric = "misc_tasks.Case2Metric"
+   task = MetricsControllerTask(config)
+
+``MetricsControllerTask`` will create and run two different ``CommonMetric`` objects, one configured with ``metric = "misc_tasks.Case1Metric"`` and one with ``metric = "misc_tasks.Case2Metric"``.
+The names ``"case1"`` and ``"case2"`` can be anything, so long as they are unique.

--- a/doc/lsst.verify/tasks/lsst.verify.compatibility.MetricsControllerTask.rst
+++ b/doc/lsst.verify/tasks/lsst.verify.compatibility.MetricsControllerTask.rst
@@ -1,0 +1,86 @@
+.. lsst-task-topic:: lsst.verify.compatibility.MetricsControllerTask
+
+.. currentmodule:: lsst.verify.compatibility
+
+#####################
+MetricsControllerTask
+#####################
+
+``MetricsControllerTask`` runs collections of :lsst-task:`lsst.verify.compatibility.MetricTask`, and stores the resulting `~lsst.verify.Measurement` objects using the `~lsst.verify.Job` persistence framework.
+It is a stand-in for functionality provided by the Gen 3 Tasks framework.
+The datasets that ``MetricsControllerTask`` consumes depend on the :lsst-task:`~lsst.verify.compatibility.MetricTask`\ s to be run, and are handled automatically.
+
+``MetricsControllerTask`` is not a command-line task, but may be called from within both task- and non-task pipelines.
+
+.. _lsst.verify.compatibility.MetricsControllerTask-summary:
+
+Processing summary
+==================
+
+Unlike most tasks, ``MetricsControllerTask`` has a `~MetricsControllerTask.runDataRefs` method that takes a list of data references.
+``MetricsControllerTask`` calls every :lsst-task:`~lsst.verify.compatibility.MetricTask` in :lsst-config-field:`~lsst.verify.compatibility.MetricsControllerConfig.measurers` on every data reference, loading any datasets necessary.
+It produces one `~lsst.verify.Job` object for each input data reference, and writes them to disk.
+
+.. _lsst.verify.compatibility.MetricsControllerTask-api:
+
+Python API summary
+==================
+
+.. lsst-task-api-summary:: lsst.verify.compatibility.MetricsControllerTask
+
+.. _lsst.verify.compatibility.MetricsControllerTask-subtasks:
+
+Retargetable subtasks
+=====================
+
+.. lsst-task-config-subtasks:: lsst.verify.compatibility.MetricsControllerTask
+
+.. _lsst.verify.compatibility.MetricsControllerTask-configs:
+
+Configuration fields
+====================
+
+.. lsst-task-config-fields:: lsst.verify.compatibility.MetricsControllerTask
+
+.. _lsst.verify.compatibility.MetricsControllerTask-indepth:
+
+In Depth
+========
+
+Because ``MetricsControllerTask`` applies every :lsst-task:`~lsst.verify.compatibility.MetricTask` to every input data reference indiscriminately, it may not give good results with metrics or data references having a mixture of granularities (e.g., CCD-level, visit-level, dataset-level).
+The recommended way around this limitation is to create multiple ``MetricsControllerTask`` objects, and configure each one for metrics of a single granularity.
+
+Each :lsst-task:`~lsst.verify.compatibility.MetricTask` in a ``MetricsControllerTask`` must measure a different metric, or they will overwrite each others' values.
+
+.. _lsst.verify.compatibility.MetricsControllerTask-examples:
+
+Examples
+========
+
+.. code-block:: py
+
+   from lsst.verify.compatibility import register, \
+       MetricTask, MetricsControllerTask
+
+
+   @register("ultimate")
+   class UltimateMetric(MetricTask):
+       ...
+
+
+   @register("second")
+   class SecondaryMetric(MetricTask):
+       ...
+
+
+   config = MetricsControllerTask.ConfigClass()
+   config.measurers = ["ultimate", "second"]
+   config.measurers["ultimate"].answer = 42
+   task = MetricsControllerTask(config)
+
+   # CCD-level metrics need CCD-level datarefs
+   # Exact dataset type doesn't matter
+   datarefs = [butler.subset("calexp", visit=42, ccd=ccd)
+               for ccd in range(1, 101)]
+   struct = task.runDataRefs(datarefs)
+   assert len(struct.jobs) == len(datarefs)

--- a/doc/lsst.verify/tasks/lsst.verify.compatibility.SquashMetadataTask.rst
+++ b/doc/lsst.verify/tasks/lsst.verify.compatibility.SquashMetadataTask.rst
@@ -1,0 +1,39 @@
+.. lsst-task-topic:: lsst.verify.compatibility.metadataTask.SquashMetadataTask
+
+##################
+SquashMetadataTask
+##################
+
+``SquashMetadataTask`` modifies a `~lsst.verify.Job` object to contain metadata that is required for SQuaSH upload.
+It is both the default for the :lsst-config-field:`lsst.verify.compatibility.MetricsControllerConfig.metadataAdder` subtask and its reference implementation.
+
+.. _lsst.verify.compatibility.SquashMetadataTask-summary:
+
+Processing summary
+==================
+
+``SquashMetadataTask`` currently adds the following metadata:
+
+* ``"instrument"``: the name of the instrument that took the data
+* the individual keys of the provided data ID (each `~lsst.verify.Job` produced by :lsst-task:`~lsst.verify.compatibility.MetricsControllerTask` is associated with one data ID, which may be partial)
+
+.. _lsst.verify.compatibility.SquashMetadataTask-api:
+
+Python API summary
+==================
+
+.. lsst-task-api-summary:: lsst.verify.compatibility.SquashMetadataTask
+
+.. _lsst.verify.compatibility.SquashMetadataTask-subtasks:
+
+Retargetable subtasks
+=====================
+
+.. lsst-task-config-subtasks:: lsst.verify.compatibility.SquashMetadataTask
+
+.. _lsst.verify.compatibility.SquashMetadataTask-configs:
+
+Configuration fields
+====================
+
+.. lsst-task-config-fields:: lsst.verify.compatibility.SquashMetadataTask

--- a/python/lsst/verify/compatibility/metricRegistry.py
+++ b/python/lsst/verify/compatibility/metricRegistry.py
@@ -19,7 +19,22 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from .metricTask import *
-from .metricsControllerTask import *
-from .metadataTask import *
-from .metricRegistry import *
+__all__ = []
+
+from lsst.pex.config import Registry
+
+
+class MetricRegistry:
+    """Registry of all `lsst.verify.compatibility.MetricTask` subclasses known
+    to `lsst.verify`'s client.
+
+    Notes
+    -----
+    This class has a singleton-like architecture in case a custom subclass of
+    `lsst.pex.config.Registry` is needed in the future. Code that refers to
+    ``MetricRegistry.registry`` should be agnostic to such changes.
+    """
+
+    registry = Registry()
+    """A unique registry of ``MetricTasks`` (`lsst.pex.config.Registry`).
+    """

--- a/python/lsst/verify/compatibility/metricRegistry.py
+++ b/python/lsst/verify/compatibility/metricRegistry.py
@@ -19,9 +19,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-__all__ = ["register"]
+__all__ = ["register", "registerMultiple"]
 
-from lsst.pex.config import Registry
+from lsst.pex.config import Config, ConfigDictField, Registry
 from .metricTask import MetricTask
 
 
@@ -68,6 +68,127 @@ def register(name):
     return wrapper
 
 
+def registerMultiple(name):
+    """A class decorator that registers a `lsst.verify.compatibility.MetricTask`
+    with a central repository.
+
+    Unlike `register`, this decorator assumes the same
+    `~lsst.verify.compatibility.MetricTask` class will be run by
+    `lsst.verify.compatibility.MetricsControllerTask` multiple times with
+    different configs.
+
+    Parameters
+    ----------
+    name : `str`
+        The name under which this decorator will register the
+        `~lsst.verify.compatibility.MetricTask`.
+
+    Raises
+    ------
+    RuntimeError
+        Raised if another class has already been registered under ``name``.
+    ValueError
+        Raised if this decorator is applied to a class that is not a
+        `lsst.verify.compatibility.MetricTask`.
+
+    Notes
+    -----
+    This decorator must be used for any `~lsst.verify.compatibility.MetricTask`
+    that will have multiple instances used with
+    `lsst.verify.compatibility.MetricsControllerTask`.
+
+    The registry entry produced by this decorator corresponds to an anonymous
+    `~lsst.pex.config.Config` class with one field, ``configs``. ``configs``
+    is a `~lsst.pex.config.ConfigDictField` that may have any number of
+    configs attached to it. The field will create multiple
+    `~lsst.verify.compatibility.MetricTask` objects, one for each config
+    provided. See :lsst-task:`~lsst.verify.compatibility.MetricsControllerTask`
+    for an example of how to use ``configs``.
+
+    Examples
+    --------
+    The decorator is applied at the class definition:
+
+    >>> from lsst.verify.compatibility import registerMultiple, MetricTask
+    >>> @registerMultiple("reusable")
+    ... class ReusableMetricTask(MetricTask):
+    ...     pass
+    """
+    def wrapper(taskClass):
+        if issubclass(taskClass, MetricTask):
+            # TODO: if MetricRegistry is phased out, simply return taskClass
+            # instead of removing the decorator
+            MetricRegistry.registry.register(
+                name,
+                _MultiConfigFactory(taskClass),
+                ConfigClass=_makeMultiConfig(taskClass.ConfigClass))
+            return taskClass
+        else:
+            raise ValueError("%r is not a %r" % (taskClass, MetricTask))
+    return wrapper
+
+
+def _makeMultiConfig(configClass):
+    """A factory function for creating a config for registerMultiple.
+
+    Parameters
+    ----------
+    configClass : `lsst.verify.compatibility.MetricTask.ConfigClass`-type
+        The type of task config to be stored inside the new config. Subclasses
+        of ``configClass`` will **NOT** be supported (this is a limitation of
+        `~lsst.pex.config.ConfigDictField`).
+
+    Returns
+    -------
+    multiConfig : `lsst.pex.config.Config`-type
+        A `~lsst.pex.config.Config` class containing the following fields:
+
+        configs : `lsst.pex.config.ConfigDictField`
+            A field that maps `str` to ``configClass``. The keys are arbitrary
+            and can be chosen for user convenience.
+    """
+    class MultiConfig(Config):
+        configs = ConfigDictField(
+            keytype=str, itemtype=configClass, optional=False,
+            default={},
+            doc="A collection of multiple configs to create multiple items "
+                "of the same type.")
+
+    return MultiConfig
+
+
+class _MultiConfigFactory:
+    """A factory class for creating multiple `MetricTask` objects at once.
+
+    Parameters
+    ----------
+    configurableClass : `lsst.verify.compatibility.MetricTask`-type
+        The type of configurable created by `__call__`.
+    """
+    def __init__(self, configurableClass):
+        self._configurableClass = configurableClass
+
+    def __call__(self, config, **kwargs):
+        """Create the configured task(s).
+
+        Parameters
+        ----------
+        config : type from ``_makeMultiConfig(configurableClass.ConfigClass)``
+            A config containing multiple configs for ``configurableClass`.
+        **kwargs
+            Additional arguments to the ``configurableClass`` constructor.
+
+        Returns
+        -------
+        tasks : iterable of ``configurableClass``
+            A sequence of ``configurableClass``, one for each config in
+            ``config``. The order in which the objects will be returned
+            is undefined.
+        """
+        return [self._configurableClass(subConfig, **kwargs)
+                for subConfig in config.configs.values()]
+
+
 class MetricRegistry:
     """Registry of all `lsst.verify.compatibility.MetricTask` subclasses known
     to `lsst.verify`'s client.
@@ -80,5 +201,6 @@ class MetricRegistry:
     """
 
     registry = Registry(MetricTask.ConfigClass)
-    """A unique registry of ``MetricTasks`` (`lsst.pex.config.Registry`).
+    """A unique registry of ``MetricTasks`` or collections of ``MetricTasks``
+    (`lsst.pex.config.Registry`).
     """

--- a/python/lsst/verify/compatibility/metricTask.py
+++ b/python/lsst/verify/compatibility/metricTask.py
@@ -28,8 +28,7 @@ import lsst.pipe.base as pipeBase
 
 
 class MetricTask(pipeBase.Task, metaclass=abc.ABCMeta):
-    """A base class for tasks that compute exactly one metric from arbitrary
-    input datasets.
+    """A base class for tasks that compute one metric from input datasets.
 
     Parameters
     ----------

--- a/python/lsst/verify/compatibility/metricsControllerTask.py
+++ b/python/lsst/verify/compatibility/metricsControllerTask.py
@@ -23,25 +23,24 @@ __all__ = ["MetricsControllerConfig", "MetricsControllerTask"]
 
 import traceback
 
-import astropy.units as u
-
 import lsst.pex.config as pexConfig
 import lsst.daf.persistence as dafPersist
 from lsst.pipe.base import Task, Struct
-from lsst.verify import Job, Measurement, Name, MetricComputationError
+from lsst.verify import Job, MetricComputationError
 from .metadataTask import SquashMetadataTask
-from .metricTask import MetricTask
+from .metricRegistry import MetricRegistry
 
 
 class MetricsControllerConfig(pexConfig.Config):
-    """Global, metric-independent options for `MetricsControllerTask`.
+    """Configuration options for `MetricsControllerTask`.
     """
     jobFileTemplate = pexConfig.Field(
         dtype=str,
         doc="A template for the path to which the measurements are "
         "written. {id} is replaced with a unique index (recommended), "
         "while {dataId} is replaced with the data ID.",
-        default="metrics{id}.{dataId}.verify.json")
+        default="metrics{id}.{dataId}.verify.json",
+    )
     metadataAdder = pexConfig.ConfigurableField(
         target=SquashMetadataTask,
         doc="Task for adding metadata needed by measurement clients. "
@@ -49,6 +48,12 @@ class MetricsControllerConfig(pexConfig.Config):
             "parameter, and should accept unknown keyword arguments. It must "
             "return a `~lsst.pipe.base.Struct` with the field ``job`` "
             "pointing to the modified job.",
+    )
+    measurers = MetricRegistry.registry.makeField(
+        multi=True,
+        doc=r"`MetricTask`\ s to call and their configuration. Each "
+            "`MetricTask` must be identified by the name passed to its "
+            "`~lsst.verify.compatibility.register` decorator.",
     )
 
 
@@ -68,15 +73,11 @@ class MetricsControllerTask(Task):
     Because ``MetricsControllerTask`` cannot support the full functionality of
     the Gen 3 framework, it places several restrictions on its metrics:
 
+        * each ``MetricTask`` must measure a unique metric
         * no ``MetricTask`` may depend on the output of another ``MetricTask``
         * the granularity of the metrics is determined by the inputs to
           ``runDataRefs``; configuration information specifying a different
           granularity is allowed but is ignored
-
-    Multiple instances of ``MetricsControllerTask`` are allowed. The
-    recommended way to handle metrics of different granularities is to group
-    metrics of the same granularity under a ``MetricsControllerTask``
-    configured for that granularity.
     """
 
     _DefaultName = "metricsController"
@@ -87,58 +88,11 @@ class MetricsControllerTask(Task):
     `lsst.verify.compatibility.MetricTask`).
     """
 
-    # TODO: remove this method in DM-16535
-    def _makeTimingTask(self, target, metric):
-        """Create a `~lsst.verify.compatibility.MetricTask` that can time
-        a specific method.
-
-        Parameters
-        ----------
-        target : `str`
-            the method to time, optionally prefixed by one or more tasks in
-            the format of `lsst.pipe.base.Task.getFullMetadata()`. All
-            matching methods are counted by the task.
-        metric : `str`
-            the fully qualified name of the metric to contain the
-            timing information
-
-        Returns
-        -------
-        task : `TimingMetricTask`
-            a ``MetricTask`` that times ``target`` and stores the information
-            in ``metric``. It assumes ``target`` is called as part of
-            `lsst.ap.pipe.ApPipeTask`.
-        """
-        config = TimingMetricTask.ConfigClass()
-        config.metadataDataset = "apPipe_metadata"
-        config.target = target
-        config.metric = metric
-        return TimingMetricTask(config=config)
-
     def __init__(self, config=None, **kwargs):
         super().__init__(config=config, **kwargs)
         self.makeSubtask("metadataAdder")
 
-        # TODO: generalize in DM-16535
-        self.measurers = [
-            self._makeTimingTask("apPipe.runDataRef", "ap_pipe.ApPipeTime"),
-            self._makeTimingTask("apPipe:ccdProcessor.runDataRef",
-                                 "pipe_tasks.ProcessCcdTime"),
-            self._makeTimingTask("apPipe:ccdProcessor:isr.runDataRef",
-                                 "ip_isr.IsrTime"),
-            self._makeTimingTask("apPipe:ccdProcessor:charImage.runDataRef",
-                                 "pipe_tasks.CharacterizeImageTime"),
-            self._makeTimingTask("apPipe:ccdProcessor:calibrate.runDataRef",
-                                 "pipe_tasks.CalibrateTime"),
-            self._makeTimingTask("apPipe:differencer.runDataRef",
-                                 "pipe_tasks.ImageDifferenceTime"),
-            self._makeTimingTask("apPipe:differencer:register.run",
-                                 "pipe_tasks.RegisterImageTime"),
-            self._makeTimingTask("apPipe:differencer:measurement.run",
-                                 "ip_diffim.DipoleFitTime"),
-            self._makeTimingTask("apPipe:associator.run",
-                                 "ap_association.AssociationTime"),
-        ]
+        self.measurers = self.config.measurers.apply()
 
     def _computeSingleMeasurement(self, job, metricTask, dataref):
         """Call a single metric task on a single dataref.
@@ -250,179 +204,3 @@ class MetricsControllerTask(Task):
         # Construct a relatively OS-friendly string (i.e., no quotes or {})
         idString = " ".join("%s=%s" % (key, dataId[key]) for key in dataId)
         return self.config.jobFileTemplate.format(id=index, dataId=idString)
-
-
-# A verbatim copy of lsst.ap.verify.measurements.profiling.TimingMetricTask,
-# to keep MetricsControllerTask from temporarily depending on ap_verify.
-# TODO: remove all code below this point in DM-16535
-
-
-class TimingMetricConfig(MetricTask.ConfigClass):
-    """Information that distinguishes one timing metric from another.
-    """
-    # It would be more user-friendly to identify the top-level task and call
-    # CmdLineTask._getMetadataName, but doing so bypasses the public API and
-    # requires reconstruction of the full task just in case the dataset is
-    # config-dependent.
-    metadataDataset = pexConfig.Field(
-        dtype=str,
-        doc="The dataset type of the timed top-level task's metadata, "
-            "such as 'processCcd_metadata'.")
-    target = pexConfig.Field(
-        dtype=str,
-        doc="The method to time, optionally prefixed by one or more tasks "
-            "in the format of `lsst.pipe.base.Task.getFullMetadata()`. "
-            "All matching methods will be counted.")
-    metric = pexConfig.Field(
-        dtype=str,
-        doc="The fully qualified name of the metric to contain the "
-            "timing information.")
-
-
-class TimingMetricTask(MetricTask):
-    """A Task that measures a timing metric using metadata produced by the
-    `lsst.pipe.base.timeMethod` decorator.
-
-    Parameters
-    ----------
-    args
-    kwargs
-        Constructor parameters are the same as for
-        `lsst.verify.compatibility.MetricTask`.
-    """
-
-    ConfigClass = TimingMetricConfig
-    _DefaultName = "timingMetric"
-
-    @classmethod
-    def _getInputMetadataKeyRoot(cls, config):
-        """A search string for the metadata.
-
-        The string must contain the name of the target method, optionally
-        prefixed by one or more tasks in the format of
-        `lsst.pipe.base.Task.getFullMetadata()`. It should be as short as
-        possible to avoid making assumptions about what subtasks are
-        configured. However, if multiple tasks and methods match the string,
-        they will be assumed to all be relevant to the metric.
-
-        Parameters
-        ----------
-        config : ``cls.ConfigClass``
-            Configuration for this task.
-
-        Returns
-        -------
-        keyRoot : `str`
-            A string identifying the class(es) and method(s) for this task.
-        """
-        return config.target
-
-    @staticmethod
-    def _searchMetadataKeys(metadata, keyFragment):
-        """Metadata search for partial keys.
-
-        Parameters
-        ----------
-        metadata : `lsst.daf.base.PropertySet`
-            A metadata object with task-qualified keys as returned by
-            `lsst.pipe.base.Task.getFullMetadata()`.
-        keyFragment : `str`
-            A substring for a full metadata key.
-
-        Returns
-        -------
-        keys : `set` of `str`
-            All keys in ``metadata`` that have ``keyFragment`` as a substring.
-        """
-        keys = metadata.paramNames(topLevelOnly=False)
-        return {key for key in keys if keyFragment in key}
-
-    def run(self, metadata):
-        """Compute a wall-clock measurement from metadata provided by
-        `lsst.pipe.base.timeMethod`.
-
-        The method shall return no metric if any element of ``metadata`` is
-        ``None``, on the grounds that if a task run was aborted without writing
-        metadata, then any timing measurement wouldn't be comparable to other
-        results anyway. It will also return no metric if no timing information
-        was provided by any of the metadata.
-
-        Parameters
-        ----------
-        metadata : iterable of `lsst.daf.base.PropertySet`
-            A collection of metadata objects, one for each unit of science
-            processing to be incorporated into this metric. Its elements
-            may be `None` to represent missing data.
-
-        Returns
-        -------
-        result : `lsst.pipe.base.Struct`
-            A Struct containing at least the following component:
-
-            - ``measurement``: the total running time of the target method
-                               across all elements of ``metadata``
-                               (`lsst.verify.Measurement` or `None`)
-
-        Raises
-        ------
-        MetricComputationError
-            Raised if any of the timing metadata are invalid.
-        """
-        keyBase = self._getInputMetadataKeyRoot(self.config)
-        endBase = keyBase + "EndCpuTime"
-
-        # some timings are indistinguishable from 0,
-        # so don't test totalTime > 0
-        timingFound = False
-        totalTime = 0.0
-        for singleMetadata in metadata:
-            if singleMetadata is not None:
-                matchingKeys = TimingMetricTask._searchMetadataKeys(
-                    singleMetadata, endBase)
-                for endKey in matchingKeys:
-                    startKey = endKey.replace("EndCpuTime", "StartCpuTime")
-                    try:
-                        # startKey not guaranteed to exist
-                        start, end = (singleMetadata.getAsDouble(key)
-                                      for key in (startKey, endKey))
-                    except (LookupError, TypeError) as e:
-                        raise MetricComputationError("Invalid metadata") \
-                            from e
-                    totalTime += end - start
-                    timingFound = True
-            else:
-                self.log.warn(
-                    "At least one run did not write metadata; aborting.")
-                return Struct(measurement=None)
-
-        if timingFound:
-            meas = Measurement(self.getOutputMetricName(self.config),
-                               totalTime * u.second)
-            meas.notes['estimator'] = 'pipe.base.timeMethod'
-        else:
-            self.log.info(
-                "Nothing to do: no timing information for %s found.",
-                keyBase)
-            meas = None
-        return Struct(measurement=meas)
-
-    @classmethod
-    def getInputDatasetTypes(cls, config):
-        """Return input dataset types for this task.
-
-        Parameters
-        ----------
-        config : ``cls.ConfigClass``
-            Configuration for this task.
-
-        Returns
-        -------
-        metadata : `dict` from `str` to `str`
-            Dictionary from ``"metadata"`` to the dataset type of
-            the target task's metadata.
-        """
-        return {'metadata': config.metadataDataset}
-
-    @classmethod
-    def getOutputMetricName(cls, config):
-        return Name(config.metric)

--- a/tests/test_metricRegistry.py
+++ b/tests/test_metricRegistry.py
@@ -1,0 +1,65 @@
+# This file is part of verify.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import unittest
+
+import lsst.utils.tests
+
+from lsst.verify.compatibility import MetricTask, register
+from lsst.verify.compatibility.metricRegistry import MetricRegistry
+
+
+class MetricRegistryTestSuite(lsst.utils.tests.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Remember the implementation class of the registry for later use
+        cls.RegistryClass = type(MetricRegistry.registry)
+
+    def setUp(self):
+        # Clear out old registry by replacing it
+        MetricRegistry.registry = self.RegistryClass()
+
+    def testRegistration(self):
+        @register("foo")
+        class DummyMetricTask(MetricTask):
+            pass
+
+        self.assertIn("foo", MetricRegistry.registry)
+        self.assertEqual(MetricRegistry.registry["foo"], DummyMetricTask)
+
+    def testInvalidRegistration(self):
+        with self.assertRaises(ValueError):
+            @register("bar")
+            class NotAMetricTask:
+                pass
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/test_metricRegistry.py
+++ b/tests/test_metricRegistry.py
@@ -23,7 +23,7 @@ import unittest
 
 import lsst.utils.tests
 
-from lsst.verify.compatibility import MetricTask, register
+from lsst.verify.compatibility import MetricTask, register, registerMultiple
 from lsst.verify.compatibility.metricRegistry import MetricRegistry
 
 
@@ -45,10 +45,26 @@ class MetricRegistryTestSuite(lsst.utils.tests.TestCase):
         self.assertIn("foo", MetricRegistry.registry)
         self.assertEqual(MetricRegistry.registry["foo"], DummyMetricTask)
 
+    def testMultiRegistration(self):
+        @registerMultiple("foo")
+        class DummyMetricTask(MetricTask):
+            pass
+
+        self.assertIn("foo", MetricRegistry.registry)
+        # Type of registry entry is implementation detail; functionality better
+        # tested in test_metricsController
+
     def testInvalidRegistration(self):
         with self.assertRaises(ValueError):
             @register("bar")
             class NotAMetricTask:
+                pass
+
+    def testInvalidMultiRegistration(self):
+        with self.assertRaises(RuntimeError):
+            @register("foo")
+            @registerMultiple("foo")
+            class DummyMetricTask(MetricTask):
                 pass
 
 


### PR DESCRIPTION
This PR adds infrastructure to `lsst.verify.compatibility` for configuring `MetricTask`s, and modifies `MetricsControllerTask` to use it. Since this change makes `MetricsControllerTask` usable outside of carefully controlled environments, this PR also adds task documentation for `MetricTask` and `MetricsControllerTask`.