### PR TITLE
DM-16642: Generalize job metadata code

### DIFF
--- a/python/lsst/verify/compatibility/__init__.py
+++ b/python/lsst/verify/compatibility/__init__.py
@@ -21,3 +21,4 @@
 
 from .metricTask import *
 from .metricsControllerTask import *
+from .metadataTask import *

--- a/python/lsst/verify/compatibility/metadataTask.py
+++ b/python/lsst/verify/compatibility/metadataTask.py
@@ -1,0 +1,91 @@
+# This file is part of verify.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__all__ = ["SquashMetadataTask"]
+
+from lsst.pex.config import Config
+from lsst.pipe.base import Task, Struct
+
+
+class SquashMetadataTask(Task):
+    """A Task for adding SQuaSH-required metadata to a Job.
+
+    This task is intended as a subtask of `MetricsControllerTask`.
+    """
+
+    _DefaultName = "squashMetadata"
+    ConfigClass = Config
+
+    @staticmethod
+    def _getInstrument(dataref):
+        """Extract the instrument name associated with a Butler dataset.
+
+        Parameters
+        ----------
+        dataref : `lsst.daf.persistence.ButlerDataRef`
+            A data reference to any dataset of interest.
+
+        Returns
+        -------
+        instrument : `str`
+            The canonical name of the instrument, in all uppercase form.
+        """
+        camera = dataref.get('camera')
+        instrument = camera.getName()
+        return instrument.upper()
+
+    def run(self, job, *, dataref, **kwargs):
+        """Add metadata to a Job object.
+
+        Parameters
+        ----------
+        job : `lsst.verify.Job`
+            The job to be instrumented with metadata. The input object will be
+            modified by this call.
+        dataref : `lsst.daf.persistence.ButlerDataRef`
+            The data reference associated with the job.
+        kwargs
+            Additional keyword arguments. These exist to support duck-typing
+            with tasks that require different inputs, and are unused.
+
+        Returns
+        -------
+        struct : `lsst.pipe.base.Struct`
+            A `~lsst.pipe.base.Struct` containing the following component:
+
+            ``job``
+                a reference to the input `~lsst.verify.Job`.
+
+        Notes
+        -----
+        The current implementation adds the following metadata:
+
+        ``"instrument"``
+            The canonical name of the instrument, in all
+            uppercase form (`str`).
+        ``[data ID key]``
+            One metadata key for each key in ``dataref``'s data ID
+            (e.g., ``"visit"``), with the corresponding value.
+        """
+        job.meta['instrument'] = SquashMetadataTask._getInstrument(dataref)
+        job.meta.update(dataref.dataId)
+
+        return Struct(job=job)

--- a/tests/test_squashMetadataTask.py
+++ b/tests/test_squashMetadataTask.py
@@ -1,0 +1,76 @@
+# This file is part of verify.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import unittest.mock
+
+import lsst.utils.tests
+from lsst.daf.persistence import ButlerDataRef
+from lsst.afw.cameraGeom import Camera
+from lsst.verify import Job
+from lsst.verify.compatibility import SquashMetadataTask
+
+
+def _makeMockDataref(dataId=None):
+    """A dataref-like object that returns a mock camera.
+    """
+    camera = unittest.mock.NonCallableMock(
+        Camera, autospec=True, **{"getName.return_value": "fancyCam"})
+    return unittest.mock.NonCallableMock(
+        ButlerDataRef, autospec=True, **{"get.return_value": camera},
+        dataId=dataId)
+
+
+class SquashMetadataTestSuite(lsst.utils.tests.TestCase):
+
+    def setUp(self):
+        self.testbed = SquashMetadataTask()
+        self.job = Job()
+
+    def _checkDataId(self, dataId):
+        dataref = _makeMockDataref(dataId)
+        self.testbed.run(self.job, dataref=dataref)
+        self.assertEqual(set(self.job.meta.keys()),
+                         {"instrument"} | dataId.keys())
+        self.assertEqual(self.job.meta["instrument"], "FANCYCAM")
+        for key, value in dataId.items():
+            self.assertEqual(self.job.meta[key], value)
+
+    def testCcdVisit(self):
+        self._checkDataId(dict(visit=42, ccd=27))
+
+    def testTractPatch(self):
+        self._checkDataId(dict(tract=76, patch="2,3"))
+
+    def testEmptyId(self):
+        self._checkDataId({})
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()


### PR DESCRIPTION
This PR factors out the SQuaSH-specific metadata keys applied by `MetricsControllerTask.runDataRefs` into a subtask, so that they can be easily replaced if the need arises. Aside from documenting the new config field in `MetricsControllerConfig`, I have not added any "user guide" documentation, as this is not a config option that most users need to be aware of.