### PR TITLE
DM-16536: Migrate all metrics from ap.verify.measurements

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -5,5 +5,4 @@ verify documentation preview
 .. toctree::
    :maxdepth: 1
 
-   verify/index.rst
    lsst.verify/index.rst

--- a/doc/lsst.verify/index.rst
+++ b/doc/lsst.verify/index.rst
@@ -102,4 +102,8 @@ Python API reference
    :no-main-docstr:
    :no-inheritance-diagram:
 
+.. automodapi:: lsst.verify.tasks
+   :no-main-docstr:
+   :no-inheritance-diagram:
+
 .. _SQUASH: https://squash.lsst.codes

--- a/doc/lsst.verify/tasks/lsst.verify.gen2tasks.MetricTask.rst
+++ b/doc/lsst.verify/tasks/lsst.verify.gen2tasks.MetricTask.rst
@@ -48,6 +48,29 @@ Each subclass must also implement the `~MetricTask.getOutputMetricName` method.
 The task config should use `lsst.pipe.base.InputDatasetConfig` to identify input datasets as if it were a `~lsst.pipe.base.PipelineTask`.
 Only the ``name`` field is used in a Gen 2 context, but use of `~lsst.pipe.base.InputDatasetConfig` is expected to simplify the transition to Gen 3.
 
+.. _lsst.verify.gen2tasks.MetricTask-indepth-errors:
+
+Error Handling
+--------------
+
+In general, a ``MetricTask`` may run in three cases:
+
+#. the task can compute the metric without incident.
+#. the task does not have the datasets required to compute the metric.
+   This often happens if the user runs generic metric configurations on arbitrary pipelines, or if they make changes to the pipeline configuration that enable or disable processing steps.
+   More rarely, it can happen when trying to compute diagnostic metrics on incomplete (i.e., failed) pipeline runs.
+#. the task has the data it needs, but cannot compute the metric.
+   This could be because the data are corrupted, because the selected algorithm fails, or because the metric is ill-defined given the data.
+
+A ``MetricTask`` must distinguish between these cases so that `~lsst.verify.gen2tasks.MetricsControllerTask` and future calling frameworks can handle them appropriately.
+A task for a metric that does not apply to a particular pipeline run (case 2) must return `None` in place of a `~lsst.verify.Measurement`.
+A task that cannot give a valid result (case 3) must raise `~lsst.verify.tasks.MetricComputationError`.
+
+In grey areas, developers should choose a ``MetricTask``'s behavior based on whether the root cause is closer to case 2 or case 3.
+For example, ``TimingMetricTask`` accepts top-level task metadata as input, but returns `None` if it can't find metadata for the subtask it is supposed to time.
+While the input dataset is available, the subtask metadata are most likely missing because the subtask was never run, making the situation equivalent to case 2.
+On the other hand, metadata with nonsense values falls squarely under case 3.
+
 .. _lsst.verify.gen2tasks.MetricTask-indepth-register:
 
 Registration

--- a/doc/lsst.verify/tasks/lsst.verify.gen2tasks.MetricsControllerTask.rst
+++ b/doc/lsst.verify/tasks/lsst.verify.gen2tasks.MetricsControllerTask.rst
@@ -18,7 +18,7 @@ Processing summary
 ==================
 
 Unlike most tasks, ``MetricsControllerTask`` has a `~MetricsControllerTask.runDataRefs` method that takes a list of data references.
-``MetricsControllerTask`` calls every :lsst-task:`~lsst.verify.gen2tasks.MetricTask` in :lsst-config-field:`~lsst.verify.gen2tasks.MetricsControllerConfig.measurers` on every data reference, loading any datasets necessary.
+``MetricsControllerTask`` calls every :lsst-task:`~lsst.verify.gen2tasks.MetricTask` in :lsst-config-field:`~lsst.verify.gen2tasks.metricsControllerTask.MetricsControllerConfig.measurers` on every data reference, loading any datasets necessary.
 It produces one `~lsst.verify.Job` object for each input data reference, and writes them to disk.
 
 .. _lsst.verify.gen2tasks.MetricsControllerTask-api:

--- a/doc/lsst.verify/tasks/lsst.verify.gen2tasks.SquashMetadataTask.rst
+++ b/doc/lsst.verify/tasks/lsst.verify.gen2tasks.SquashMetadataTask.rst
@@ -5,7 +5,7 @@ SquashMetadataTask
 ##################
 
 ``SquashMetadataTask`` modifies a `~lsst.verify.Job` object to contain metadata that is required for SQuaSH upload.
-It is both the default for the :lsst-config-field:`lsst.verify.gen2tasks.MetricsControllerConfig.metadataAdder` subtask and its reference implementation.
+It is both the default for the :lsst-config-field:`lsst.verify.gen2tasks.metricsControllerTask.MetricsControllerConfig.metadataAdder` subtask and its reference implementation.
 
 .. _lsst.verify.gen2tasks.SquashMetadataTask-summary:
 

--- a/doc/lsst.verify/tasks/lsst.verify.tasks.ConfigPpdbLoader.rst
+++ b/doc/lsst.verify/tasks/lsst.verify.tasks.ConfigPpdbLoader.rst
@@ -1,0 +1,40 @@
+.. lsst-task-topic:: lsst.verify.tasks.ppdbMetricTask.ConfigPpdbLoader
+
+################
+ConfigPpdbLoader
+################
+
+``ConfigPpdbLoader`` creates a `lsst.dax.ppdb.Ppdb` object from a science task config that contains a `~lsst.dax.ppdb.PpdbConfig`.
+This provides users with a `~lsst.dax.ppdb.Ppdb` object that accesses the same database as the original science task.
+
+This task is intended for use as a subtask of :lsst-task:`lsst.verify.tasks.ppdbMetricTask.PpdbMetricTask`.
+
+.. _lsst.verify.tasks.ConfigPpdbLoader-summary:
+
+Processing summary
+==================
+
+``ConfigPpdbLoader`` takes a config as input, and searches it and all sub-configs for a `lsst.dax.ppdb.PpdbConfig`.
+If it finds one, it constructs a `~lsst.dax.ppdb.Ppdb` object based on that config and returns it.
+If the input config has multiple `~lsst.dax.ppdb.PpdbConfig` sub-configs, ``ConfigPpdbLoader`` does not make any guarantees about which one will be used.
+
+.. _lsst.verify.tasks.ConfigPpdbLoader-api:
+
+Python API summary
+==================
+
+.. lsst-task-api-summary:: lsst.verify.tasks.ConfigPpdbLoader
+
+.. _lsst.verify.tasks.ConfigPpdbLoader-subtasks:
+
+Retargetable subtasks
+=====================
+
+.. lsst-task-config-subtasks:: lsst.verify.tasks.ConfigPpdbLoader
+
+.. _lsst.verify.tasks.ConfigPpdbLoader-configs:
+
+Configuration fields
+====================
+
+.. lsst-task-config-fields:: lsst.verify.tasks.ConfigPpdbLoader

--- a/doc/lsst.verify/tasks/lsst.verify.tasks.MetadataMetricTask.rst
+++ b/doc/lsst.verify/tasks/lsst.verify.tasks.MetadataMetricTask.rst
@@ -1,0 +1,55 @@
+.. lsst-task-topic:: lsst.verify.tasks.MetadataMetricTask
+
+##################
+MetadataMetricTask
+##################
+
+``MetadataMetricTask`` is a base class for generating `~lsst.verify.Measurement`\ s from task metadata.
+The class handles loading metadata and extracting the keys of interest, while subclasses are responsible for creating the `~lsst.verify.Measurement` from the extracted values.
+
+``MetadataMetricTask`` is currently a subclass of `lsst.verify.gen2tasks.MetricTask`.
+It is expected that ``MetadataMetricTask`` can be migrated to the Gen 3 framework without affecting its subclasses.
+
+.. _lsst.verify.tasks.MetadataMetricTask-summary:
+
+Processing summary
+==================
+
+``MetadataMetricTask`` runs this sequence of operations:
+
+#. Find the metadata key(s) needed to compute the metric by calling the customizable `~lsst.verify.tasks.MetadataMetricTask.getInputMetadataKeys` method.
+#. Search all the metadata objects passed to `~lsst.verify.tasks.MetadataMetricTask.run` for the keys, and extract the corresponding values.
+#. Process the values by calling the customizable `~lsst.verify.tasks.MetadataMetricTask.makeMeasurement` method, and return the `~lsst.verify.Measurement`.
+
+.. _lsst.verify.tasks.MetadataMetricTask-api:
+
+Python API summary
+==================
+
+.. lsst-task-api-summary:: lsst.verify.tasks.MetadataMetricTask
+
+.. _lsst.verify.tasks.MetadataMetricTask-butler:
+
+Butler datasets
+===============
+
+Input datasets
+--------------
+
+:lsst-config-field:`~lsst.verify.tasks.MetadataMetricTask.MetadataMetricConfig.metadata`
+    The metadata of the top-level command-line task (e.g., ``ProcessCcdTask``, ``ApPipeTask``) being instrumented.
+    Because the metadata produced by each top-level task is a different Butler dataset type, this dataset **must** be explicitly configured when running ``MetadataMetricTask`` or a :lsst-task:`~lsst.verify.gen2tasks.MetricsControllerTask` that contains it.
+
+.. _lsst.verify.tasks.MetadataMetricTask-subtasks:
+
+Retargetable subtasks
+=====================
+
+.. lsst-task-config-subtasks:: lsst.verify.tasks.MetadataMetricTask
+
+.. _lsst.verify.tasks.MetadataMetricTask-configs:
+
+Configuration fields
+====================
+
+.. lsst-task-config-fields:: lsst.verify.tasks.MetadataMetricTask

--- a/doc/lsst.verify/tasks/lsst.verify.tasks.PpdbMetricTask.rst
+++ b/doc/lsst.verify/tasks/lsst.verify.tasks.PpdbMetricTask.rst
@@ -1,0 +1,56 @@
+.. lsst-task-topic:: lsst.verify.tasks.ppdbMetricTask.PpdbMetricTask
+
+##############
+PpdbMetricTask
+##############
+
+``PpdbMetricTask`` is a base class for generating `~lsst.verify.Measurement`\ s from a prompt products database.
+The class handles loading an appropriately configured database, while subclasses are responsible for creating the `~lsst.verify.Measurement` using the database API.
+
+``PpdbMetricTask`` is currently a subclass of `lsst.verify.gen2tasks.MetricTask`.
+It is expected that ``PpdbMetricTask`` can be migrated to the Gen 3 framework without affecting its subclasses.
+
+.. _lsst.verify.tasks.PpdbMetricTask-summary:
+
+Processing summary
+==================
+
+``PpdbMetricTask`` runs this sequence of operations:
+
+#. Load the dataset indicated by :lsst-config-field:`~lsst.verify.tasks.ppdbMetricTask.PpdbMetricConfig.dbInfo` (default: the top-level science task's config).
+#. Generate a `~lsst.dax.ppdb.Ppdb` object by calling the :lsst-config-field:`~lsst.verify.tasks.ppdbMetricTask.PpdbMetricConfig.dbLoader` subtask (default: :lsst-task:`~lsst.verify.tasks.ppdbMetricTask.ConfigPpdbLoader`).
+#. Process the database by passing it to the customizable `~lsst.verify.tasks.ppdbMetricTask.PpdbMetricTask.makeMeasurement` method, and return the `~lsst.verify.Measurement`.
+
+.. _lsst.verify.tasks.PpdbMetricTask-api:
+
+Python API summary
+==================
+
+.. lsst-task-api-summary:: lsst.verify.tasks.PpdbMetricTask
+
+.. _lsst.verify.tasks.PpdbMetricTask-butler:
+
+Butler datasets
+===============
+
+Input datasets
+--------------
+
+:lsst-config-field:`~lsst.verify.tasks.ppdbMetricTask.PpdbMetricConfig.dbInfo`
+    The Butler dataset from which the database connection can be initialized.
+    The type must match the input required by the :lsst-config-field:`~lsst.verify.tasks.ppdbMetricTask.PpdbMetricConfig.dbLoader` subtask (default: the top-level science task's config).
+    If the input is a config, its name **must** be explicitly configured when running ``PpdbMetricTask`` or a :lsst-task:`~lsst.verify.gen2tasks.MetricsControllerTask` that contains it.
+
+.. _lsst.verify.tasks.PpdbMetricTask-subtasks:
+
+Retargetable subtasks
+=====================
+
+.. lsst-task-config-subtasks:: lsst.verify.tasks.PpdbMetricTask
+
+.. _lsst.verify.tasks.PpdbMetricTask-configs:
+
+Configuration fields
+====================
+
+.. lsst-task-config-fields:: lsst.verify.tasks.PpdbMetricTask

--- a/python/lsst/verify/__init__.py
+++ b/python/lsst/verify/__init__.py
@@ -43,4 +43,3 @@ from .blobset import *
 from .jobmetadata import *
 from .job import *
 from .output import *
-from .metricTask import *

--- a/python/lsst/verify/gen2tasks/metricRegistry.py
+++ b/python/lsst/verify/gen2tasks/metricRegistry.py
@@ -187,7 +187,7 @@ class _MultiConfigFactory:
             ``config``. The order in which the objects will be returned
             is undefined.
         """
-        return [self._configurableClass(subConfig, **kwargs)
+        return [self._configurableClass(config=subConfig, **kwargs)
                 for subConfig in config.configs.values()]
 
 

--- a/python/lsst/verify/gen2tasks/metricTask.py
+++ b/python/lsst/verify/gen2tasks/metricTask.py
@@ -60,6 +60,9 @@ class MetricTask(pipeBase.Task, metaclass=abc.ABCMeta):
     # Butler datasets
     ConfigClass = lsst.pex.config.Config
 
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
     def adaptArgsAndRun(self, inputData, inputDataIds, outputDataId):
         """Compute a metric from in-memory data.
 

--- a/python/lsst/verify/gen2tasks/metricTask.py
+++ b/python/lsst/verify/gen2tasks/metricTask.py
@@ -118,9 +118,12 @@ class MetricTask(pipeBase.Task, metaclass=abc.ABCMeta):
         `addStandardMetadata` on its measurement before returning it.
 
         `adaptArgsAndRun` and `run` should assume they take multiple input
-        datasets, regardless of the expected metric granularity. This rule may
-        be broken if it is impossible for more than one copy of a dataset
-        to exist.
+        datasets, regardless of the expected metric granularity. Doing so lets
+        metrics be defined with a different granularity from the Science
+        Pipelines processing, and allows for the aggregation (or lack thereof)
+        of the metric to be controlled by the task configuration with no code
+        changes. This rule may be broken if it is impossible for more than one
+        copy of a dataset to exist.
 
         All input data must be treated as optional. This maximizes the
         ``MetricTask``'s usefulness for incomplete pipeline runs or runs with

--- a/python/lsst/verify/gen2tasks/metricTask.py
+++ b/python/lsst/verify/gen2tasks/metricTask.py
@@ -97,12 +97,12 @@ class MetricTask(pipeBase.Task, metaclass=abc.ABCMeta):
 
         Raises
         ------
-        lsst.verify.MetricComputationError
+        lsst.verify.tasks.MetricComputationError
             Raised if an algorithmic or system error prevents calculation
             of the metric. Examples include corrupted input data or
             unavoidable exceptions raised by analysis code. The
-            `~lsst.verify.MetricComputationError` should be chained to a more
-            specific exception describing the root cause.
+            `~lsst.verify.tasks.MetricComputationError` should be chained to a
+            more specific exception describing the root cause.
 
             Not having enough data for a metric to be applicable is not an
             error, and should not trigger this exception.

--- a/python/lsst/verify/gen2tasks/metricsControllerTask.py
+++ b/python/lsst/verify/gen2tasks/metricsControllerTask.py
@@ -26,7 +26,8 @@ import traceback
 import lsst.pex.config as pexConfig
 import lsst.daf.persistence as dafPersist
 from lsst.pipe.base import Task, Struct
-from lsst.verify import Job, MetricComputationError
+from lsst.verify import Job
+from lsst.verify.tasks import MetricComputationError
 from .metadataTask import SquashMetadataTask
 from .metricRegistry import MetricRegistry
 

--- a/python/lsst/verify/gen2tasks/metricsControllerTask.py
+++ b/python/lsst/verify/gen2tasks/metricsControllerTask.py
@@ -166,6 +166,10 @@ class MetricsControllerTask(Task):
             value = result.measurement
             if value is not None:
                 job.measurements.insert(value)
+            else:
+                self.log.debug(
+                    "Skipping measurement of %r on %s as not applicable.",
+                    metricTask, inputDataIds)
         except MetricComputationError:
             # Apparently lsst.log doesn't have built-in exception support?
             self.log.error("Measurement of %r failed on %s->%s\n%s",
@@ -177,7 +181,8 @@ class MetricsControllerTask(Task):
 
         This method loads all datasets required to compute a particular
         metric, and persists the metrics as one or more `lsst.verify.Job`
-        objects.
+        objects. Only metrics that successfully produce a
+        `~lsst.verify.Measurement` will be included in a job.
 
         Parameters
         ----------

--- a/python/lsst/verify/gen2tasks/metricsControllerTask.py
+++ b/python/lsst/verify/gen2tasks/metricsControllerTask.py
@@ -234,5 +234,5 @@ class MetricsControllerTask(Task):
             The identifier of all metrics in the Job to be persisted.
         """
         # Construct a relatively OS-friendly string (i.e., no quotes or {})
-        idString = " ".join("%s=%s" % (key, dataId[key]) for key in dataId)
+        idString = "_".join("%s%s" % (key, dataId[key]) for key in dataId)
         return self.config.jobFileTemplate.format(id=index, dataId=idString)

--- a/python/lsst/verify/gen2tasks/testUtils.py
+++ b/python/lsst/verify/gen2tasks/testUtils.py
@@ -23,6 +23,7 @@
 
 __all__ = ["MetricTaskTestCase"]
 
+import abc
 import unittest.mock
 import inspect
 
@@ -32,7 +33,7 @@ from lsst.pipe.base import Struct
 from lsst.verify import Measurement
 
 
-class MetricTaskTestCase(lsst.utils.tests.TestCase):
+class MetricTaskTestCase(lsst.utils.tests.TestCase, metaclass=abc.ABCMeta):
     """Unit test base class for tests of `gen2tasks.MetricTask`.
 
     This class provides tests of the generic ``MetricTask`` API. Subclasses
@@ -40,16 +41,18 @@ class MetricTaskTestCase(lsst.utils.tests.TestCase):
     functionality. If subclasses override `setUp`, they must call
     `MetricTaskTestCase.setUp`.
     """
+    @classmethod
+    @abc.abstractmethod
+    def makeTask(cls):
+        """Construct the task to be tested.
 
-    # For some reason, setUp for the test cases defined in MetricTaskTestCase
-    # calls the wrong factory if you make it a classmethod
-    taskFactory = None
-    """A nullary callable that constructs the `gen2tasks.MetricTask`
-    to be tested.
+        This overridable method will be called during test setup.
 
-    If a concrete task's constructor satisfies the requirements, its type
-    object may be used as the factory.
-    """
+        Returns
+        -------
+        task : `lsst.verify.gen2tasks.MetricTask`
+            A new MetricTask object to test.
+        """
 
     task = None
     """The ``MetricTask`` being tested by this object
@@ -72,7 +75,7 @@ class MetricTaskTestCase(lsst.utils.tests.TestCase):
         This implementation calls `taskFactory`, then initializes `task`
         and `taskClass`.
         """
-        self.task = self.taskFactory()
+        self.task = self.makeTask()
         self.taskClass = type(self.task)
 
     # Implementation classes will override run or adaptArgsAndRun. Can't

--- a/python/lsst/verify/gen2tasks/testUtils.py
+++ b/python/lsst/verify/gen2tasks/testUtils.py
@@ -115,6 +115,6 @@ class MetricTaskTestCase(lsst.utils.tests.TestCase, metaclass=abc.ABCMeta):
             result = self.task.adaptArgsAndRun(
                 {key: [None] for key in inputParams},
                 {key: [dataId] for key in inputParams},
-                {'measurement': {}})
+                {'measurement': dataId})
             mockDict['addStandardMetadata'].assert_called_once_with(
                 self.task, result.measurement, dataId)

--- a/python/lsst/verify/tasks/__init__.py
+++ b/python/lsst/verify/tasks/__init__.py
@@ -20,3 +20,4 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from .metricTask import *
+from .metadataMetricTask import *

--- a/python/lsst/verify/tasks/__init__.py
+++ b/python/lsst/verify/tasks/__init__.py
@@ -1,0 +1,22 @@
+# This file is part of verify.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from .metricTask import *

--- a/python/lsst/verify/tasks/__init__.py
+++ b/python/lsst/verify/tasks/__init__.py
@@ -21,3 +21,4 @@
 
 from .metricTask import *
 from .metadataMetricTask import *
+from .ppdbMetricTask import *

--- a/python/lsst/verify/tasks/metadataMetricTask.py
+++ b/python/lsst/verify/tasks/metadataMetricTask.py
@@ -1,0 +1,231 @@
+# This file is part of verify.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__all__ = ["MetadataMetricTask", "MetadataMetricConfig"]
+
+import abc
+
+from lsst.pipe.base import Struct, InputDatasetField
+from lsst.verify.gen2tasks import MetricTask
+from lsst.verify.tasks import MetricComputationError
+
+
+class MetadataMetricConfig(MetricTask.ConfigClass):
+    """A base class for metadata metric task configs.
+
+    Notes
+    -----
+    `MetadataMetricTask` classes that have CCD-level granularity can use
+    this class as-is. Classes representing metrics of a different granularity
+    should use `setDefaults` to override ``metadata.dimensions``.
+    """
+    metadata = InputDatasetField(
+        doc="The target top-level task's metadata. The name must be set to "
+            "the metadata's butler type, such as 'processCcd_metadata'.",
+        nameTemplate="{taskName}_metadata",
+        storageClass="PropertySet",
+        dimensions={"Instrument", "Exposure", "Detector"},
+    )
+
+
+class MetadataMetricTask(MetricTask):
+    """A base class for tasks that compute metrics from metadata values.
+
+    Parameters
+    ----------
+    *args
+    **kwargs
+        Constructor parameters are the same as for
+        `lsst.pipe.base.PipelineTask`.
+
+    Notes
+    -----
+    This class should be customized by overriding `getInputMetadataKeys`,
+    `makeMeasurement`, and `getOutputMetricName`. You should not need to
+    override `run`.
+
+    This class makes no assumptions about how to handle missing data;
+    `makeMeasurement` may be called with `None` values, and is responsible
+    for deciding how to deal with them.
+    """
+    # Design note: getInputMetadataKeys and makeMeasurement are overrideable
+    # methods rather than subtask(s) to keep the configs for
+    # `MetricsControllerTask` as simple as possible. This was judged more
+    # important than ensuring that no implementation details of MetricTask
+    # can leak into application-specific code.
+
+    ConfigClass = MetadataMetricConfig
+
+    @classmethod
+    @abc.abstractmethod
+    def getInputMetadataKeys(cls, config):
+        """Return the metadata keys read by this task.
+
+        Parameters
+        ----------
+        config : ``cls.ConfigClass``
+            Configuration for this task.
+
+        Returns
+        -------
+        keys : `dict` [`str`, `str`]
+            The keys are the (arbitrary) names of values needed by
+            `makeMeasurement`, the values are the metadata keys to be looked
+            up. Metadata keys are assumed to include task prefixes in the
+            format of `lsst.pipe.base.Task.getFullMetadata()`. This method may
+            return a substring of the desired (full) key, but multiple matches
+            for any key will cause an error.
+        """
+
+    @abc.abstractmethod
+    def makeMeasurement(self, values):
+        """Compute the metric given the values of the metadata.
+
+        Parameters
+        ----------
+        values : sequence [`dict` [`str`, any]]
+            A list where each element corresponds to a metadata object passed
+            to `run`. Each `dict` has the same keys as returned by
+            `getInputMetadataKeys`, and maps them to the values extracted from
+            the metadata. Any value may be `None` to represent missing data.
+
+        Returns
+        -------
+        measurement : `lsst.verify.Measurement` or `None`
+            The measurement corresponding to the input data.
+
+        Raises
+        ------
+        lsst.verify.tasks.MetricComputationError
+            Raised if an algorithmic or system error prevents calculation of
+            the metric. See `adaptArgsAndRun` for expected behavior.
+
+        Notes
+        -----
+        As with all `lsst.verify.gen2tasks.MetricTask` subclasses, this method
+        should assume a many-to-one relationship between input data and the
+        resulting metric, i.e., it should not assume that the output metric
+        and the input data have the same granularity. In the common case that
+        they do, ``values`` will contain only one element.
+        """
+
+    @staticmethod
+    def _searchKeys(metadata, keyFragment):
+        """Search the metadata for all keys matching a substring.
+
+        Parameters
+        ----------
+        metadata : `lsst.daf.base.PropertySet`
+            A metadata object with task-qualified keys as returned by
+            `lsst.pipe.base.Task.getFullMetadata()`.
+        keyFragment : `str`
+            A substring for a full metadata key.
+
+        Returns
+        -------
+        keys : `set` of `str`
+            All keys in ``metadata`` that have ``keyFragment`` as a substring.
+        """
+        keys = metadata.paramNames(topLevelOnly=False)
+        return {key for key in keys if keyFragment in key}
+
+    @staticmethod
+    def _extractMetadata(metadata, metadataKeys):
+        """Read multiple keys from a metadata object.
+
+        Parameters
+        ----------
+        metadata : `lsst.daf.base.PropertySet`
+            A metadata object, assumed not `None`.
+        metadataKeys : `dict` [`str`, `str`]
+            Keys are arbitrary labels, values are metadata keys (or their
+            substrings) in the format of
+            `lsst.pipe.base.Task.getFullMetadata()`.
+
+        Returns
+        -------
+        metadataValues : `dict` [`str`, any]
+            Keys are the same as for ``metadataKeys``, values are the value of
+            each metadata key, or `None` if no matching key was found.
+
+        Raises
+        ------
+        lsst.verify.tasks.MetricComputationError
+            Raised if any metadata key string has more than one match
+            in ``metadata``.
+        """
+        data = {}
+        for dataName, keyFragment in metadataKeys.items():
+            matchingKeys = MetadataMetricTask._searchKeys(
+                metadata, keyFragment)
+            if len(matchingKeys) == 1:
+                key, = matchingKeys
+                data[dataName] = metadata.getScalar(key)
+            elif not matchingKeys:
+                data[dataName] = None
+            else:
+                error = "String %s matches multiple metadata keys: %s" \
+                    % (keyFragment, matchingKeys)
+                raise MetricComputationError(error)
+        return data
+
+    def run(self, metadata):
+        """Compute a measurement from science task metadata.
+
+        Parameters
+        ----------
+        metadata : iterable of `lsst.daf.base.PropertySet`
+            A collection of metadata objects, one for each unit of science
+            processing to be incorporated into this metric. Its elements
+            may be `None` to represent missing data.
+
+        Returns
+        -------
+        result : `lsst.pipe.base.Struct`
+            A `~lsst.pipe.base.Struct` containing the following component:
+
+            - ``measurement``: the value of the metric
+              (`lsst.verify.Measurement` or `None`)
+
+        Raises
+        ------
+        lsst.verify.tasks.MetricComputationError
+            Raised if the strings returned by `getInputMetadataKeys` match
+            more than one key in any metadata object.
+
+        Notes
+        -----
+        This implementation calls `getInputMetadataKeys`, then searches for
+        matching keys in each element of ``metadata``. It then passes the
+        values of these keys (or `None` if no match) to `makeMeasurement`, and
+        returns its result to the caller.
+        """
+        metadataKeys = self.getInputMetadataKeys(self.config)
+
+        values = []
+        for singleMetadata in metadata:
+            if singleMetadata is not None:
+                data = self._extractMetadata(singleMetadata, metadataKeys)
+                values.append(data)
+            else:
+                values.append({dataName: None for dataName in metadataKeys})
+
+        return Struct(measurement=self.makeMeasurement(values))

--- a/python/lsst/verify/tasks/metricTask.py
+++ b/python/lsst/verify/tasks/metricTask.py
@@ -26,11 +26,11 @@ __all__ = ["MetricComputationError"]
 class MetricComputationError(RuntimeError):
     """This class represents unresolvable errors in computing a metric.
 
-    `gen2tasks.MetricTask` raises ``MetricComputationError`` instead of
-    other data- or processing-related exceptions to let code that calls a mix
-    of data processing and metric tasks distinguish between the two.
-    Therefore, most ``MetricComputationError`` instances should be chained to
-    another exception representing the underlying problem.
+    `lsst.verify.gen2tasks.MetricTask` raises ``MetricComputationError``
+    instead of other data- or processing-related exceptions to let code that
+    calls a mix of data processing and metric tasks distinguish between
+    the two. Therefore, most ``MetricComputationError`` instances should be
+    chained to another exception representing the underlying problem.
     """
     pass
 

--- a/python/lsst/verify/tasks/ppdbMetricTask.py
+++ b/python/lsst/verify/tasks/ppdbMetricTask.py
@@ -1,0 +1,337 @@
+# This file is part of verify.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__all__ = ["PpdbMetricTask", "PpdbMetricConfig", "ConfigPpdbLoader"]
+
+import abc
+
+from lsst.pex.config import Config, ConfigurableField, ConfigurableInstance, \
+    ConfigDictField, ConfigChoiceField, FieldValidationError
+from lsst.pipe.base import Task, Struct, InputDatasetField
+from lsst.dax.ppdb import Ppdb, PpdbConfig
+
+from lsst.verify.gen2tasks import MetricTask
+
+
+class ConfigPpdbLoader(Task):
+    """A Task that takes a science task config and returns the corresponding
+    Ppdb object.
+
+    Parameters
+    ----------
+    *args
+    **kwargs
+        Constructor parameters are the same as for `lsst.pipe.base.Task`.
+    """
+    _DefaultName = "configPpdb"
+    ConfigClass = Config
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def _getPpdb(self, config):
+        """Extract a Ppdb object from an arbitrary task config.
+
+        Parameters
+        ----------
+        config : `lsst.pex.config.Config` or `None`
+            A config that may contain a `lsst.dax.ppdb.PpdbConfig`.
+            Behavior is undefined if there is more than one such member.
+
+        Returns
+        -------
+        ppdb : `lsst.dax.ppdb.Ppdb`-like or `None`
+            A `lsst.dax.ppdb.Ppdb` object or a drop-in replacement, or `None`
+            if no `lsst.dax.ppdb.PpdbConfig` is present in ``config``.
+        """
+        if config is None:
+            return None
+        if isinstance(config, PpdbConfig):
+            return Ppdb(config)
+
+        for field in config.values():
+            if isinstance(field, ConfigurableInstance):
+                result = self._getPpdbFromConfigurableField(field)
+                if result:
+                    return result
+            elif isinstance(field, ConfigChoiceField.instanceDictClass):
+                try:
+                    # can't test with hasattr because of non-standard getattr
+                    field.names
+                except FieldValidationError:
+                    result = self._getPpdb(field.active)
+                else:
+                    result = self._getPpdbFromConfigIterable(field.active)
+                if result:
+                    return result
+            elif isinstance(field, ConfigDictField.DictClass):
+                result = self._getPpdbFromConfigIterable(field.values())
+                if result:
+                    return result
+            elif isinstance(field, Config):
+                # Can't test for `ConfigField` more directly than this
+                result = self._getPpdb(field)
+                if result:
+                    return result
+        return None
+
+    def _getPpdbFromConfigurableField(self, configurable):
+        """Extract a Ppdb object from a ConfigurableField.
+
+        Parameters
+        ----------
+        configurable : `lsst.pex.config.ConfigurableInstance` or `None`
+            A configurable that may contain a `lsst.dax.ppdb.PpdbConfig`.
+
+        Returns
+        -------
+        ppdb : `lsst.dax.ppdb.Ppdb`-like or `None`
+            A `lsst.dax.ppdb.Ppdb` object or a drop-in replacement, if a
+            suitable config exists.
+        """
+        if configurable is None:
+            return None
+
+        if configurable.ConfigClass == PpdbConfig:
+            return configurable.apply()
+        else:
+            return self._getPpdb(configurable.value)
+
+    def _getPpdbFromConfigIterable(self, configDict):
+        """Extract a Ppdb object from an iterable of configs.
+
+        Parameters
+        ----------
+        configDict: iterable of `lsst.pex.config.Config` or `None`
+            A config iterable that may contain a `lsst.dax.ppdb.PpdbConfig`.
+
+        Returns
+        -------
+        ppdb : `lsst.dax.ppdb.Ppdb`-like or `None`
+            A `lsst.dax.ppdb.Ppdb` object or a drop-in replacement, if a
+            suitable config exists.
+        """
+        if configDict:
+            for config in configDict:
+                result = self._getPpdb(config)
+                if result:
+                    return result
+        return None
+
+    def run(self, config):
+        """Create a database consistent with a science task config.
+
+        Parameters
+        ----------
+        config : `lsst.pex.config.Config`
+            A config that should contain a `lsst.dax.ppdb.PpdbConfig`.
+            Behavior is undefined if there is more than one such member.
+
+        Returns
+        -------
+        result : `lsst.pipe.base.Struct`
+            Result struct with components:
+
+            ``ppdb``
+                A database configured the same way as in ``config``, if one
+                exists (`lsst.dax.ppdb.Ppdb` or `None`).
+        """
+        return Struct(ppdb=self._getPpdb(config))
+
+
+class PpdbMetricConfig(MetricTask.ConfigClass):
+    """A base class for PPDB metric task configs.
+    """
+    dbInfo = InputDatasetField(
+        doc="The dataset from which a PPDB instance can be constructed by "
+            "`dbLoader`. By default this is assumed to be a top-level "
+            "config, such as 'processCcd_config'.",
+        nameTemplate="{taskName}_config",
+        storageClass="Config",
+        # One config for entire CmdLineTask run
+        scalar=True,
+        dimensions=set(),
+    )
+    dbLoader = ConfigurableField(
+        target=ConfigPpdbLoader,
+        doc="Task for loading a database from `dbInfo`. Its run method must "
+        "take the dataset provided by `dbInfo` and return a Struct with a "
+        "'ppdb' member."
+    )
+
+
+class PpdbMetricTask(MetricTask):
+    """A base class for tasks that compute metrics from a prompt products
+    database.
+
+    Parameters
+    ----------
+    **kwargs
+        Constructor parameters are the same as for
+        `lsst.pipe.base.PipelineTask`.
+
+    Notes
+    -----
+    This class should be customized by overriding `makeMeasurement` and
+    `getOutputMetricName`. You should not need to override `run` or
+    `adaptArgsAndRun`.
+    """
+    # Design note: makeMeasurement is an overrideable method rather than a
+    # subtask to keep the configs for `MetricsControllerTask` as simple as
+    # possible. This was judged more important than ensuring that no
+    # implementation details of MetricTask can leak into
+    # application-specific code.
+
+    ConfigClass = PpdbMetricConfig
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        self.makeSubtask("dbLoader")
+
+    @abc.abstractmethod
+    def makeMeasurement(self, dbHandle, outputDataId):
+        """Compute the metric from database data.
+
+        Parameters
+        ----------
+        dbHandle : `lsst.dax.ppdb.Ppdb`
+            A database instance.
+        outputDataId : any data ID type
+            The subset of the database to which this measurement applies.
+            May be empty to represent the entire dataset.
+
+        Returns
+        -------
+        measurement : `lsst.verify.Measurement` or `None`
+            The measurement corresponding to the input data.
+
+        Raises
+        ------
+        MetricComputationError
+            Raised if an algorithmic or system error prevents calculation of
+            the metric. See `adaptArgsAndRun` for expected behavior.
+        """
+
+    def run(self, dbInfo):
+        """Compute a measurement from a database.
+
+        Parameters
+        ----------
+        dbInfo
+            The dataset (of the type indicated by `getInputDatasetTypes`) from
+            which to load the database.
+
+        Returns
+        -------
+        result : `lsst.pipe.base.Struct`
+            Result struct with component:
+
+            ``measurement``
+                the value of the metric computed over the entire database
+                (`lsst.verify.Measurement` or `None`)
+
+        Raises
+        ------
+        MetricComputationError
+            Raised if an algorithmic or system error prevents calculation of
+            the metric.
+
+        Notes
+        -----
+        This method is provided purely for compatibility with frameworks that
+        don't support `adaptArgsAndRun`. The latter method should be considered
+        the primary entry point for this task, as it lets callers define
+        metrics that apply to only a subset of the data.
+        """
+        return self.adaptArgsAndRun({"dbInfo": dbInfo},
+                                    {"dbInfo": {}},
+                                    {"measurement": {}})
+
+    def adaptArgsAndRun(self, inputData, inputDataIds, outputDataId):
+        """Compute a measurement from a database.
+
+        Parameters
+        ----------
+        inputData : `dict` [`str`, any]
+            Dictionary with one key:
+
+            ``"dbInfo"``
+                The dataset (of the type indicated by `getInputDatasetTypes`)
+                from which to load the database. A single-element list
+                containing a dataset is allowed for compatibility with
+                `~lsst.verify.gen2tasks.MetricsControllerTask`, but should
+                otherwise not be used.
+        inputDataIds : `dict` [`str`, data ID]
+            Dictionary with one key:
+
+            ``"dbInfo"``
+                The data ID of the input data. Since there can only be one
+                prompt products database per dataset, the value must be an
+                empty data ID.
+        outputDataId : `dict` [`str`, data ID]
+            Dictionary with one key:
+
+            ``"measurement"``
+                The data ID for the measurement, at the appropriate level
+                of granularity for the metric.
+
+        Returns
+        -------
+        result : `lsst.pipe.base.Struct`
+            Result struct with component:
+
+            ``measurement``
+                the value of the metric computed over the portion of the
+                dataset that matches ``outputDataId``
+                (`lsst.verify.Measurement` or `None`)
+
+        Raises
+        ------
+        lsst.verify.tasks.MetricComputationError
+            Raised if an algorithmic or system error prevents calculation of
+            the metric.
+
+        Notes
+        -----
+        This implementation calls
+        `~lsst.verify.tasks.PpdbMetricConfig.dbLoader` to acquire a database
+        handle, then passes it and the value of ``outputDataId`` to
+        `makeMeasurement`. The result of `makeMeasurement` is returned to
+        the caller.
+        """
+        dataId = outputDataId["measurement"]
+        dbInfo = inputData["dbInfo"]
+        try:
+            dbInfo = dbInfo[0]
+        except TypeError:
+            pass
+
+        db = self.dbLoader.run(dbInfo).ppdb
+
+        if db is not None:
+            measurement = self.makeMeasurement(db, dataId)
+        else:
+            measurement = None
+        if measurement is not None:
+            self.addStandardMetadata(measurement, dataId)
+
+        return Struct(measurement=measurement)

--- a/python/lsst/verify/tasks/testUtils.py
+++ b/python/lsst/verify/tasks/testUtils.py
@@ -1,0 +1,73 @@
+# This file is part of verify.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__all__ = ["MetadataMetricTestCase"]
+
+import unittest.mock
+
+from lsst.daf.base import PropertySet
+from lsst.verify.gen2tasks.testUtils import MetricTaskTestCase
+from lsst.verify.tasks import MetricComputationError
+
+
+class MetadataMetricTestCase(MetricTaskTestCase):
+    """Unit test base class for tests of `MetadataMetricTask`.
+
+    Notes
+    -----
+    Subclasses must override
+    `~lsst.verify.gen2tasks.MetricTaskTestCase.makeTask` for the concrete task
+    being tested.
+    """
+
+    def testInputDatasetTypes(self):
+        defaultInputs = self.taskClass.getInputDatasetTypes(self.task.config)
+        self.assertEqual(defaultInputs.keys(), {"metadata"})
+
+    def testValidRun(self):
+        mockKey = "unitTestKey"
+        with unittest.mock.patch.object(self.task, "getInputMetadataKeys",
+                                        return_value={"unused": mockKey}):
+            with unittest.mock.patch.object(self.task, "makeMeasurement") \
+                    as mockWorkhorse:
+                metadata1 = PropertySet()
+                metadata1[mockKey] = 42
+                metadata2 = PropertySet()
+                metadata2[mockKey] = "Sphere"
+                self.task.run([metadata1, None, metadata2])
+                mockWorkhorse.assert_called_once_with(
+                    [{"unused": value} for value in [42, None, "Sphere"]])
+
+    def testAmbiguousRun(self):
+        mockKey = "unitTestKey"
+        with unittest.mock.patch.object(self.task, "getInputMetadataKeys",
+                                        return_value={"unused": mockKey}):
+            metadata = PropertySet()
+            metadata[mockKey + "1"] = 42
+            metadata[mockKey + "2"] = "Sphere"
+            with self.assertRaises(MetricComputationError):
+                self.task.run([metadata])
+
+    def testPassThroughRun(self):
+        with unittest.mock.patch.object(self.task, "makeMeasurement",
+                                        side_effect=MetricComputationError):
+            with self.assertRaises(MetricComputationError):
+                self.task.run([None])

--- a/tests/test_configPpdbLoader.py
+++ b/tests/test_configPpdbLoader.py
@@ -1,0 +1,206 @@
+# This file is part of verify.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import unittest
+
+import lsst.utils.tests
+from lsst.pex.config import Config, Field, ConfigField, ConfigChoiceField, \
+    RegistryField, Registry, ConfigurableField, ConfigurableInstance, \
+    ConfigDictField
+from lsst.dax.ppdb import Ppdb, PpdbConfig
+
+from lsst.verify.tasks import ConfigPpdbLoader
+
+
+class ConfigPpdbLoaderTestSuite(lsst.utils.tests.TestCase):
+
+    @staticmethod
+    def _dummyRegistry():
+        class DummyConfigurable:
+            ConfigClass = Config
+        registry = Registry()
+        registry.register("foo", DummyConfigurable)
+        registry.register("bar", Ppdb, ConfigClass=PpdbConfig)
+        return registry
+
+    @staticmethod
+    def _dummyPpdbConfig():
+        config = PpdbConfig()
+        config.db_url = "sqlite://"     # in-memory DB
+        config.isolation_level = "READ_UNCOMMITTED"
+        return config
+
+    def setUp(self):
+        self.task = ConfigPpdbLoader()
+
+    def testNoConfig(self):
+        result = self.task.run(None)
+        self.assertIsNone(result.ppdb)
+
+    def testEmptyConfig(self):
+        result = self.task.run(Config())
+        self.assertIsNone(result.ppdb)
+
+    def testSelfConfig(self):
+        result = self.task.run(self._dummyPpdbConfig())
+        self.assertIsInstance(result.ppdb, Ppdb)
+
+    def testConfigChoiceFieldUnSelected(self):
+        typemap = {"foo": Config, "bar": PpdbConfig}
+
+        class TestConfig(Config):
+            field = ConfigChoiceField(typemap=typemap, doc="")
+
+        config = TestConfig()
+        config.field = "foo"
+        result = self.task.run(config)
+        self.assertIsNone(result.ppdb)
+
+    def testConfigChoiceFieldSelected(self):
+        typemap = {"foo": Config, "bar": PpdbConfig}
+
+        class TestConfig(Config):
+            field = ConfigChoiceField(typemap=typemap, doc="")
+
+        config = TestConfig()
+        config.field = "bar"
+        config.field["bar"] = self._dummyPpdbConfig()
+        result = self.task.run(config)
+        self.assertIsInstance(result.ppdb, Ppdb)
+
+    def testConfigChoiceFieldMulti(self):
+        typemap = {"foo": Config, "bar": PpdbConfig}
+
+        class TestConfig(Config):
+            field = ConfigChoiceField(typemap=typemap, doc="", multi=True)
+
+        config = TestConfig()
+        config.field = {"bar", "foo"}
+        config.field["bar"] = self._dummyPpdbConfig()
+        result = self.task.run(config)
+        self.assertIsInstance(result.ppdb, Ppdb)
+
+    def testRegistryFieldUnSelected(self):
+        registry = self._dummyRegistry()
+
+        class TestConfig(Config):
+            field = RegistryField(registry=registry, doc="")
+
+        config = TestConfig()
+        config.field = "foo"
+        result = self.task.run(config)
+        self.assertIsNone(result.ppdb)
+
+    def testRegistryFieldSelected(self):
+        registry = self._dummyRegistry()
+
+        class TestConfig(Config):
+            field = RegistryField(registry=registry, doc="")
+
+        config = TestConfig()
+        config.field = "bar"
+        config.field["bar"] = self._dummyPpdbConfig()
+        result = self.task.run(config)
+        self.assertIsInstance(result.ppdb, Ppdb)
+
+    def testRegistryFieldMulti(self):
+        registry = self._dummyRegistry()
+
+        class TestConfig(Config):
+            field = RegistryField(registry=registry, doc="", multi=True)
+
+        config = TestConfig()
+        config.field = {"bar", "foo"}
+        config.field["bar"] = self._dummyPpdbConfig()
+        result = self.task.run(config)
+        self.assertIsInstance(result.ppdb, Ppdb)
+
+    def testConfigField(self):
+        class TestConfig(Config):
+            field = ConfigField(dtype=PpdbConfig,
+                                default=self._dummyPpdbConfig(), doc="")
+
+        result = self.task.run(TestConfig())
+        self.assertIsInstance(result.ppdb, Ppdb)
+
+    def testConfigurableField(self):
+        class TestConfig(Config):
+            field = ConfigurableField(target=Ppdb, ConfigClass=PpdbConfig,
+                                      doc="")
+
+        config = TestConfig()
+        config.field = self._dummyPpdbConfig()
+        self.assertIsInstance(config.field, ConfigurableInstance)
+        result = self.task.run(config)
+        self.assertIsInstance(result.ppdb, Ppdb)
+
+    def testConfigDictFieldUnSelected(self):
+        class TestConfig(Config):
+            field = ConfigDictField(keytype=int, itemtype=PpdbConfig, doc="")
+
+        result = self.task.run(TestConfig())
+        self.assertIsNone(result.ppdb)
+
+    def testConfigDictFieldSelected(self):
+        class TestConfig(Config):
+            field = ConfigDictField(keytype=int, itemtype=PpdbConfig, doc="")
+
+        config = TestConfig()
+        config.field = {42: self._dummyPpdbConfig()}
+        result = self.task.run(config)
+        self.assertIsInstance(result.ppdb, Ppdb)
+
+    def testSiblingConfigs(self):
+        class TestConfig(Config):
+            field1 = Field(dtype=int, doc="")
+            field2 = ConfigField(dtype=PpdbConfig,
+                                 default=self._dummyPpdbConfig(), doc="")
+            field3 = Field(dtype=str, doc="")
+
+        result = self.task.run(TestConfig())
+        self.assertIsInstance(result.ppdb, Ppdb)
+
+    def testNestedConfigs(self):
+        class InnerConfig(Config):
+            field = ConfigurableField(target=Ppdb,
+                                      ConfigClass=PpdbConfig, doc="")
+
+        class TestConfig(Config):
+            field = ConfigField(dtype=InnerConfig, doc="")
+
+        config = TestConfig()
+        config.field.field = self._dummyPpdbConfig()
+        self.assertIsInstance(config.field.field, ConfigurableInstance)
+        result = self.task.run(config)
+        self.assertIsInstance(result.ppdb, Ppdb)
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/test_metricsController.py
+++ b/tests/test_metricsController.py
@@ -27,7 +27,8 @@ from astropy.tests.helper import assert_quantity_allclose
 import lsst.utils.tests
 from lsst.pex.config import Config, FieldValidationError
 from lsst.pipe.base import Task, Struct
-from lsst.verify import Job, Name, Measurement, MetricComputationError
+from lsst.verify import Job, Name, Measurement
+from lsst.verify.tasks import MetricComputationError
 from lsst.verify.gen2tasks import \
     MetricTask, MetricsControllerTask, register, registerMultiple
 

--- a/ups/verify.table
+++ b/ups/verify.table
@@ -10,6 +10,7 @@ setupRequired(log)
 setupRequired(pytest_flake8)
 setupRequired(pex_config)
 setupRequired(pipe_base)
+setupRequired(dax_ppdb)
 
 # verify_metrics is the default metrics repo and is used in tests
 setupRequired(verify_metrics)


### PR DESCRIPTION
This PR adds two abstract subclasses of `MetricTask` (`MetadataMetricTask` and `PpdbMetricTask`), along with corresponding documentation. It also fixes a number of bugs and usability issues found while testing DM-16536.