### PR TITLE
DM-18490: Move TimingMetricTask to verify

### DIFF
--- a/doc/lsst.verify/tasks/lsst.verify.gen2tasks.MetricTask.rst
+++ b/doc/lsst.verify/tasks/lsst.verify.gen2tasks.MetricTask.rst
@@ -67,7 +67,7 @@ A task for a metric that does not apply to a particular pipeline run (case 2) mu
 A task that cannot give a valid result (case 3) must raise `~lsst.verify.tasks.MetricComputationError`.
 
 In grey areas, developers should choose a ``MetricTask``'s behavior based on whether the root cause is closer to case 2 or case 3.
-For example, ``TimingMetricTask`` accepts top-level task metadata as input, but returns `None` if it can't find metadata for the subtask it is supposed to time.
+For example, :lsst-task:`~lsst.verify.tasks.commonMetrics.TimingMetricTask` accepts top-level task metadata as input, but returns `None` if it can't find metadata for the subtask it is supposed to time.
 While the input dataset is available, the subtask metadata are most likely missing because the subtask was never run, making the situation equivalent to case 2.
 On the other hand, metadata with nonsense values falls squarely under case 3.
 

--- a/doc/lsst.verify/tasks/lsst.verify.gen2tasks.MetricsControllerTask.rst
+++ b/doc/lsst.verify/tasks/lsst.verify.gen2tasks.MetricsControllerTask.rst
@@ -28,12 +28,14 @@ Python API summary
 
 .. lsst-task-api-summary:: lsst.verify.gen2tasks.MetricsControllerTask
 
-.. _lsst.verify.gen2tasks.MetricsControllerTask-subtasks:
+.. TODO: uncomment this block after resolving DM-18496
 
-Retargetable subtasks
-=====================
-
-.. lsst-task-config-subtasks:: lsst.verify.gen2tasks.MetricsControllerTask
+.. .. _lsst.verify.gen2tasks.MetricsControllerTask-subtasks:
+..
+.. Retargetable subtasks
+.. =====================
+..
+.. .. lsst-task-config-subtasks:: lsst.verify.gen2tasks.MetricsControllerTask
 
 .. _lsst.verify.gen2tasks.MetricsControllerTask-configs:
 

--- a/doc/lsst.verify/tasks/lsst.verify.tasks.TimingMetricTask.rst
+++ b/doc/lsst.verify/tasks/lsst.verify.tasks.TimingMetricTask.rst
@@ -4,7 +4,7 @@
 TimingMetricTask
 ################
 
-``TimingMetricTask`` creates a `~lsst.verify.Measurement` based on data collected by @\ `~lsst.pipe.base.timeMethod`.
+``TimingMetricTask`` creates a wall-clock timing `~lsst.verify.Measurement` based on data collected by @\ `~lsst.pipe.base.timeMethod`.
 It reads the raw timing data from the top-level `~lsst.pipe.base.CmdLineTask`'s metadata, which is identified by the task configuration.
 
 .. _lsst.verify.tasks.TimingMetricTask-summary:

--- a/doc/lsst.verify/tasks/lsst.verify.tasks.TimingMetricTask.rst
+++ b/doc/lsst.verify/tasks/lsst.verify.tasks.TimingMetricTask.rst
@@ -1,0 +1,69 @@
+.. lsst-task-topic:: lsst.verify.tasks.commonMetrics.TimingMetricTask
+
+################
+TimingMetricTask
+################
+
+``TimingMetricTask`` creates a `~lsst.verify.Measurement` based on data collected by @\ `~lsst.pipe.base.timeMethod`.
+It reads the raw timing data from the top-level `~lsst.pipe.base.CmdLineTask`'s metadata, which is identified by the task configuration.
+
+.. _lsst.verify.tasks.TimingMetricTask-summary:
+
+Processing summary
+==================
+
+``TimingMetricTask`` searches the metadata for @\ `~lsst.pipe.base.timeMethod`-generated keys corresponding to the method of interest.
+If it finds matching keys, it stores the elapsed time as a `~lsst.verify.Measurement`.
+
+.. _lsst.verify.tasks.TimingMetricTask-api:
+
+Python API summary
+==================
+
+.. lsst-task-api-summary:: lsst.verify.tasks.commonMetrics.TimingMetricTask
+
+.. _lsst.verify.tasks.TimingMetricTask-butler:
+
+Butler datasets
+===============
+
+Input datasets
+--------------
+
+:lsst-config-field:`~lsst.verify.tasks.commonMetrics.TimingMetricConfig.metadata`
+    The metadata of the top-level command-line task (e.g., ``ProcessCcdTask``, ``ApPipeTask``) being instrumented.
+    Because the metadata produced by each top-level task is a different Butler dataset type, this dataset **must** be explicitly configured when running ``TimingMetricTask`` or a :lsst-task:`~lsst.verify.gen2tasks.MetricsControllerTask` that contains it.
+
+.. _lsst.verify.tasks.TimingMetricTask-subtasks:
+
+Retargetable subtasks
+=====================
+
+.. lsst-task-config-subtasks:: lsst.verify.tasks.commonMetrics.TimingMetricTask
+
+.. _lsst.verify.tasks.TimingMetricTask-configs:
+
+Configuration fields
+====================
+
+.. lsst-task-config-fields:: lsst.verify.tasks.commonMetrics.TimingMetricTask
+
+.. _lsst.verify.tasks.TimingMetricTask-examples:
+
+Examples
+========
+
+.. code-block:: py
+
+   from lsst.verify.tasks import TimingMetricTask
+
+   config = TimingMetricTask.ConfigClass()
+   config.metadata.name = "apPipe_metadata"
+   config.target = "apPipe:ccdProcessor.runDataRef"
+   config.metric = "pipe_tasks.ProcessCcdTime"
+   task = TimingMetricTask(config)
+
+   # config.metadata provided for benefit of MetricsControllerTask/Pipeline
+   # but since we've defined it we might as well use it
+   metadata = butler.get(config.metadata.name)
+   processCcdTime = task.run(metadata).measurement

--- a/python/lsst/verify/bin/inspectjob.py
+++ b/python/lsst/verify/bin/inspectjob.py
@@ -1,4 +1,4 @@
-# This file is part of ap_verify.
+# This file is part of verify.
 #
 # Developed for the LSST Data Management System.
 # This product includes software developed by the LSST Project

--- a/python/lsst/verify/tasks/__init__.py
+++ b/python/lsst/verify/tasks/__init__.py
@@ -22,3 +22,4 @@
 from .metricTask import *
 from .metadataMetricTask import *
 from .ppdbMetricTask import *
+from .commonMetrics import *

--- a/python/lsst/verify/tasks/commonMetrics.py
+++ b/python/lsst/verify/tasks/commonMetrics.py
@@ -1,0 +1,147 @@
+#
+# This file is part of verify.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""Code for measuring metrics that apply to any Task.
+"""
+
+__all__ = ["TimingMetricConfig", "TimingMetricTask"]
+
+import astropy.units as u
+
+import lsst.pex.config as pexConfig
+
+from lsst.verify import Measurement, Name
+from lsst.verify.gen2tasks.metricRegistry import registerMultiple
+from lsst.verify.tasks import MetricComputationError, MetadataMetricTask
+
+
+class TimingMetricConfig(MetadataMetricTask.ConfigClass):
+    """Information that distinguishes one timing metric from another.
+    """
+    target = pexConfig.Field(
+        dtype=str,
+        doc="The method to time, optionally prefixed by one or more tasks "
+            "in the format of `lsst.pipe.base.Task.getFullMetadata()`.")
+    metric = pexConfig.Field(
+        dtype=str,
+        doc="The fully qualified name of the metric to store the "
+            "timing information.")
+
+
+@registerMultiple("timing")
+class TimingMetricTask(MetadataMetricTask):
+    """A Task that computes a wall-clock time using metadata produced by the
+    `lsst.pipe.base.timeMethod` decorator.
+
+    Parameters
+    ----------
+    args
+    kwargs
+        Constructor parameters are the same as for
+        `lsst.verify.gen2tasks.MetricTask`.
+    """
+
+    ConfigClass = TimingMetricConfig
+    _DefaultName = "timingMetric"
+
+    @classmethod
+    def getInputMetadataKeys(cls, config):
+        """Get search strings for the metadata.
+
+        Parameters
+        ----------
+        config : ``cls.ConfigClass``
+            Configuration for this task.
+
+        Returns
+        -------
+        keys : `dict`
+            A dictionary of keys, optionally prefixed by one or more tasks in
+            the format of `lsst.pipe.base.Task.getFullMetadata()`.
+
+             ``"StartTime"``
+                 The key for when the target method started (`str`).
+             ``"EndTime"``
+                 The key for when the target method ended (`str`).
+        """
+        keyBase = config.target
+        return {"StartTime": keyBase + "StartCpuTime",
+                "EndTime": keyBase + "EndCpuTime"}
+
+    def makeMeasurement(self, timings):
+        """Compute a wall-clock measurement from metadata provided by
+        `lsst.pipe.base.timeMethod`.
+
+        Parameters
+        ----------
+        timings : sequence [`dict` [`str`, any]]
+            A list where each element corresponds to a metadata object passed
+            to `run`. Each `dict` has the following keys:
+
+             ``"StartTime"``
+                 The time the target method started (`float` or `None`).
+             ``"EndTime"``
+                 The time the target method ended (`float` or `None`).
+
+        Returns
+        -------
+        measurement : `lsst.verify.Measurement` or `None`
+            The the total running time of the target method across all
+            elements of ``metadata``.
+
+        Raises
+        ------
+        MetricComputationError
+            Raised if any of the timing metadata are invalid.
+
+        Notes
+        -----
+        This method does not return a measurement if no timing information was
+        provided by any of the metadata.
+        """
+        # some timings indistinguishable from 0, so don't test totalTime > 0
+        timingFound = False
+        totalTime = 0.0
+        for singleRun in timings:
+            if singleRun["StartTime"] is not None \
+                    or singleRun["EndTime"] is not None:
+                try:
+                    totalTime += singleRun["EndTime"] - singleRun["StartTime"]
+                    timingFound = True
+                except TypeError:
+                    raise MetricComputationError("Invalid metadata")
+            # If both are None, assume the method was not run that time
+
+        if timingFound:
+            meas = Measurement(self.getOutputMetricName(self.config),
+                               totalTime * u.second)
+            meas.notes['estimator'] = 'pipe.base.timeMethod'
+            return meas
+        else:
+            self.log.info("Nothing to do: no timing information for %s found.",
+                          self.config.target)
+            return None
+
+    @classmethod
+    def getOutputMetricName(cls, config):
+        return Name(config.metric)

--- a/tests/test_commonMetrics.py
+++ b/tests/test_commonMetrics.py
@@ -1,0 +1,230 @@
+#
+# This file is part of verify.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import unittest
+
+import numpy as np
+import astropy.units as u
+from astropy.tests.helper import assert_quantity_allclose
+
+import lsst.utils.tests
+import lsst.afw.image as afwImage
+from lsst.ip.isr import FringeTask
+
+from lsst.verify import Measurement, Name
+from lsst.verify.gen2tasks.testUtils import MetricTaskTestCase
+from lsst.verify.tasks import MetricComputationError, TimingMetricTask
+from lsst.verify.tasks.testUtils import MetadataMetricTestCase
+
+
+def _createFringe(width, height, filterName):
+    """Create a fringe frame
+
+    Parameters
+    ----------
+    width, height: `int`
+        Size of image
+    filterName: `str`
+        name of the filterName to use
+
+    Returns
+    -------
+    fringe: `lsst.afw.image.ExposureF`
+        Fringe frame
+    """
+    image = afwImage.ImageF(width, height)
+    array = image.getArray()
+    freq = np.pi / 10.0
+    x, y = np.indices(array.shape)
+    array[x, y] = np.sin(freq * x) + np.sin(freq * y)
+    exp = afwImage.makeExposure(afwImage.makeMaskedImage(image))
+    exp.setFilter(afwImage.Filter(filterName))
+    return exp
+
+
+class TimingMetricTestSuite(MetadataMetricTestCase):
+    _SCIENCE_TASK_NAME = "fringe"
+
+    @classmethod
+    def makeTask(cls):
+        return TimingMetricTask(config=cls._standardConfig())
+
+    @staticmethod
+    def _standardConfig():
+        config = TimingMetricTask.ConfigClass()
+        config.metadata.name = TimingMetricTestSuite._SCIENCE_TASK_NAME \
+            + "_metadata"
+        config.target = TimingMetricTestSuite._SCIENCE_TASK_NAME + ".run"
+        config.metric = "ip_isr.IsrTime"
+        return config
+
+    def setUp(self):
+        """Create a dummy instance of `FringeTask` so that test cases can
+        run and measure it.
+        """
+        super().setUp()
+        self.config = TimingMetricTestSuite._standardConfig()
+
+        # Create dummy filter and fringe so that `FringeTask` has short but
+        # significant run time.
+        # Code adapted from lsst.ip.isr.test_fringes
+        size = 128
+        dummyFilter = "FILTER"
+        afwImage.utils.defineFilter(dummyFilter, lambdaEff=0)
+        exp = _createFringe(size, size, dummyFilter)
+
+        # Create and run `FringeTask` itself
+        config = FringeTask.ConfigClass()
+        config.filters = [dummyFilter]
+        config.num = 1000
+        config.small = 1
+        config.large = size // 4
+        config.pedestal = False
+        self.scienceTask = FringeTask(
+            name=TimingMetricTestSuite._SCIENCE_TASK_NAME, config=config)
+
+        # As an optimization, let test cases choose to run the dummy task
+        def runTask():
+            self.scienceTask.run(exp, exp)
+        self.runTask = runTask
+
+    def tearDown(self):
+        del self.scienceTask
+
+    def testValid(self):
+        self.runTask()
+        result = self.task.run([self.scienceTask.getFullMetadata()])
+        meas = result.measurement
+
+        self.assertIsInstance(meas, Measurement)
+        self.assertEqual(meas.metric_name, Name(metric=self.config.metric))
+        self.assertGreater(meas.quantity, 0.0 * u.second)
+        # Task normally takes 0.2 s, so this should be a safe margin of error
+        self.assertLess(meas.quantity, 10.0 * u.second)
+
+    def testNoMetric(self):
+        self.runTask()
+        self.config.metric = "foo.bar.FooBarTime"
+        task = TimingMetricTask(config=self.config)
+        with self.assertRaises(TypeError):
+            task.run([self.scienceTask.getFullMetadata()])
+
+    def testMissingData(self):
+        result = self.task.run([None])
+        meas = result.measurement
+        self.assertIsNone(meas)
+
+    def testNoDataExpected(self):
+        result = self.task.run([])
+        meas = result.measurement
+        self.assertIsNone(meas)
+
+    def testRunDifferentMethod(self):
+        self.runTask()
+        self.config.target = TimingMetricTestSuite._SCIENCE_TASK_NAME \
+            + ".runDataRef"
+        task = TimingMetricTask(config=self.config)
+        result = task.run([self.scienceTask.getFullMetadata()])
+        meas = result.measurement
+        self.assertIsNone(meas)
+
+    def testNonsenseKeys(self):
+        self.runTask()
+        metadata = self.scienceTask.getFullMetadata()
+        startKeys = [key
+                     for key in metadata.paramNames(topLevelOnly=False)
+                     if "StartCpuTime" in key]
+        for key in startKeys:
+            metadata.remove(key)
+
+        task = TimingMetricTask(config=self.config)
+        with self.assertRaises(MetricComputationError):
+            task.run([metadata])
+
+    def testBadlyTypedKeys(self):
+        self.runTask()
+        metadata = self.scienceTask.getFullMetadata()
+        endKeys = [key
+                   for key in metadata.paramNames(topLevelOnly=False)
+                   if "EndCpuTime" in key]
+        for key in endKeys:
+            metadata.set(key, str(metadata.getAsDouble(key)))
+
+        task = TimingMetricTask(config=self.config)
+        with self.assertRaises(MetricComputationError):
+            task.run([metadata])
+
+    def testGetInputDatasetTypes(self):
+        types = TimingMetricTask.getInputDatasetTypes(self.config)
+        self.assertSetEqual(set(types.keys()), {"metadata"})
+        expected = TimingMetricTestSuite._SCIENCE_TASK_NAME + "_metadata"
+        self.assertEqual(types["metadata"], expected)
+
+    def testFineGrainedMetric(self):
+        self.runTask()
+        metadata = self.scienceTask.getFullMetadata()
+        inputData = {"metadata": [metadata]}
+        inputDataIds = {"metadata": [{"visit": 42, "ccd": 1}]}
+        outputDataId = {"measurement": {"visit": 42, "ccd": 1}}
+        measDirect = self.task.run([metadata]).measurement
+        measIndirect = self.task.adaptArgsAndRun(
+            inputData, inputDataIds, outputDataId).measurement
+
+        assert_quantity_allclose(measIndirect.quantity, measDirect.quantity)
+
+    def testCoarseGrainedMetric(self):
+        self.runTask()
+        metadata = self.scienceTask.getFullMetadata()
+        nCcds = 3
+        inputData = {"metadata": [metadata] * nCcds}
+        inputDataIds = {"metadata": [{"visit": 42, "ccd": x}
+                                     for x in range(nCcds)]}
+        outputDataId = {"measurement": {"visit": 42}}
+        measDirect = self.task.run([metadata]).measurement
+        measMany = self.task.adaptArgsAndRun(
+            inputData, inputDataIds, outputDataId).measurement
+
+        assert_quantity_allclose(measMany.quantity,
+                                 nCcds * measDirect.quantity)
+
+    def testGetOutputMetricName(self):
+        self.assertEqual(TimingMetricTask.getOutputMetricName(self.config),
+                         Name(self.config.metric))
+
+
+# Hack around unittest's hacky test setup system
+del MetricTaskTestCase
+del MetadataMetricTestCase
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/ups/verify.table
+++ b/ups/verify.table
@@ -11,7 +11,6 @@ setupRequired(pytest_flake8)
 setupRequired(pex_config)
 setupRequired(pipe_base)
 setupRequired(dax_ppdb)
-setupRequired(ip_isr)
 
 # verify_metrics is the default metrics repo and is used in tests
 setupRequired(verify_metrics)

--- a/ups/verify.table
+++ b/ups/verify.table
@@ -11,6 +11,7 @@ setupRequired(pytest_flake8)
 setupRequired(pex_config)
 setupRequired(pipe_base)
 setupRequired(dax_ppdb)
+setupRequired(ip_isr)
 
 # verify_metrics is the default metrics repo and is used in tests
 setupRequired(verify_metrics)


### PR DESCRIPTION
This PR migrates `lsst.ap.verify.measurements.profiling.TimingMetricTask` to `lsst.verify.tasks.commonMetrics.TimingMetricTask`, along with its task topic page and unit tests. It also makes some tweaks to the task documentation.