### PR TITLE
DM-18900: Raise RuntimeError if replacing specs/partials

### DIFF
--- a/tests/test_specification_set.py
+++ b/tests/test_specification_set.py
@@ -102,7 +102,7 @@ class TestSpecificationSet(unittest.TestCase):
     def test_iadd(self):
         """Test SpecifcationSet.__iadd__."""
         set1 = SpecificationSet([self.spec_PA1_design, self.spec_PA1_stretch])
-        set2 = SpecificationSet([self.spec_PA1_design, self.spec_PA2_design])
+        set2 = SpecificationSet([self.spec_PA2_design])
 
         set1 += set2
 
@@ -114,7 +114,7 @@ class TestSpecificationSet(unittest.TestCase):
     def test_update(self):
         """Test SpecificationSet.update()."""
         set1 = SpecificationSet([self.spec_PA1_design, self.spec_PA1_stretch])
-        set2 = SpecificationSet([self.spec_PA1_design, self.spec_PA2_design])
+        set2 = SpecificationSet([self.spec_PA2_design])
 
         set1.update(set2)
 
@@ -193,9 +193,8 @@ class TestSpecificationSetGetterSetter(unittest.TestCase):
         self.assertFalse('validate_drp.PA1.stretch' in spec_set)
 
         # Insert duplicate
-        spec_set[spec_PA1_design.name] = spec_PA1_design
-        self.assertEqual(len(spec_set), 1)
-        self.assertTrue('validate_drp.PA1.design' in spec_set)
+        with self.assertRaises(RuntimeError):
+            spec_set[spec_PA1_design.name] = spec_PA1_design
 
         # Insert weird value
         with self.assertRaises(TypeError):


### PR DESCRIPTION
It seems that silently overwriting specifications or partials is leading to hard-to-debug issues. This makes SpecificationSet raise a RuntimeError exception if specifications or partials are being ingested
that replace previously-ingested specifications or partials of the same name.

This also consolidates the act few setting the internals _specs and _partials dicts to the __getitem__ method. Regular code shouldn't be touching _specs or _partials.

Adjust tests to deal with new behavior

**I'm not sure this should be merged yet because there may be cases where replacement is useful (such as in an update method). Let's figure out how to make replacement possible when useful, but not when a YAML package is being ingested.**