### PR TITLE
DM-16736: Let MetricsControllerTask store application-specific metadata

### DIFF
--- a/python/lsst/verify/gen2tasks/metricsControllerTask.py
+++ b/python/lsst/verify/gen2tasks/metricsControllerTask.py
@@ -176,7 +176,7 @@ class MetricsControllerTask(Task):
                            metricTask, inputDataIds, outputDataIds,
                            traceback.format_exc())
 
-    def runDataRefs(self, datarefs):
+    def runDataRefs(self, datarefs, customMetadata=None):
         """Call all registered metric tasks on each dataref.
 
         This method loads all datasets required to compute a particular
@@ -191,6 +191,13 @@ class MetricsControllerTask(Task):
             generates a measurement at the same granularity (e.g., a
             dataref with only ``"visit"`` specified generates visit-level
             measurements).
+        customMetadata : `dict`, optional
+            Any metadata that are needed for a specific pipeline, but that are
+            not needed by the ``lsst.verify`` framework or by general-purpose
+            measurement analysis code (these cases are handled by the
+            `~MetricsControllerConfig.metadataAdder` subtask). If omitted,
+            only generic metadata are added. Both keys and values must be valid
+            inputs to `~lsst.verify.Metadata`.
 
         Returns
         -------
@@ -214,6 +221,8 @@ class MetricsControllerTask(Task):
             job = Job.load_metrics_package()
             try:
                 self.metadataAdder.run(job, dataref=dataref)
+                if customMetadata:
+                    job.meta.update(customMetadata)
 
                 for task in self.measurers:
                     self._computeSingleMeasurement(job, task, dataref)

--- a/tests/test_metricsController.py
+++ b/tests/test_metricsController.py
@@ -266,6 +266,18 @@ class MetricsControllerTestSuite(lsst.utils.tests.TestCase):
         with self.assertRaises(FieldValidationError):
             self.config.measurers = ["totallyAndDefinitelyNotARealMetric"]
 
+    def testCustomMetadata(self, _mockWriter, _mockButler, _mockMetricsLoader):
+        dataIds = [{"visit": 42, "ccd": 101, "filter": "k"},
+                   {"visit": 42, "ccd": 102, "filter": "k"}]
+        datarefs = [_makeMockDataref(dataId) for dataId in dataIds]
+        extraMetadata = {"test_protocol": 42}
+        jobs = self.task.runDataRefs(datarefs, extraMetadata).jobs
+
+        for job in jobs:
+            self.assertTrue(job.meta["tested"])
+            self.assertEqual(job.meta["test_protocol"],
+                             extraMetadata["test_protocol"])
+
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):
     pass


### PR DESCRIPTION
This PR lets packages like `ap_verify` and `validate_drp` add their own metadata to jobs created by `MetricsControllerTask` without having to create a custom metadata adder (e.g., a subtask of `SquashMetadataTask`) or modify `verify` code. There isn't any specific metadata that we or DRP need to add at the moment, but this capability may be useful as `verify` gets adopted more broadly.