### PR TITLE
DM-18906: Use safe YAML loading in verify

### DIFF
--- a/python/lsst/verify/yamlutils.py
+++ b/python/lsst/verify/yamlutils.py
@@ -80,7 +80,8 @@ def load_all_ordered_yaml(stream, **kwargs):
     return yaml.load_all(stream, OrderedLoader)
 
 
-def _build_ordered_loader(Loader=yaml.Loader, object_pairs_hook=OrderedDict):
+def _build_ordered_loader(Loader=yaml.CSafeLoader,
+                          object_pairs_hook=OrderedDict):
     # Solution from http://stackoverflow.com/a/21912744
 
     class OrderedLoader(Loader):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -17,7 +17,7 @@ class MetricTestCase(unittest.TestCase):
         yaml_path = os.path.join(os.path.dirname(__file__),
                                  'data', 'metrics', 'testing.yaml')
         with open(yaml_path) as f:
-            self.metric_doc = yaml.load(f)
+            self.metric_doc = yaml.safe_load(f)
 
     def test_load_all_yaml_metrics(self):
         """Verify that all metrics from testing.yaml can be loaded."""


### PR DESCRIPTION
This PR removes all `YAMLLoadWarning`s from building `verify`. I also manually searched for `yaml.load` calls that are not exercised by the unit tests, but didn't find any.