### PR TITLE
DM-20702: Create memory usage metric

### DIFF
--- a/doc/lsst.verify/tasks/lsst.verify.tasks.MemoryMetricTask.rst
+++ b/doc/lsst.verify/tasks/lsst.verify.tasks.MemoryMetricTask.rst
@@ -1,0 +1,69 @@
+.. lsst-task-topic:: lsst.verify.tasks.commonMetrics.MemoryMetricTask
+
+################
+MemoryMetricTask
+################
+
+``MemoryMetricTask`` creates a resident set size `~lsst.verify.Measurement` based on data collected by @\ `~lsst.pipe.base.timeMethod`.
+It reads the raw timing data from the top-level `~lsst.pipe.base.CmdLineTask`'s metadata, which is identified by the task configuration.
+
+.. _lsst.verify.tasks.MemoryMetricTask-summary:
+
+Processing summary
+==================
+
+``MemoryMetricTask`` searches the metadata for @\ `~lsst.pipe.base.timeMethod`-generated keys corresponding to the method of interest.
+If it finds matching keys, it stores the maximum memory usage as a `~lsst.verify.Measurement`.
+
+.. _lsst.verify.tasks.MemoryMetricTask-api:
+
+Python API summary
+==================
+
+.. lsst-task-api-summary:: lsst.verify.tasks.commonMetrics.MemoryMetricTask
+
+.. _lsst.verify.tasks.MemoryMetricTask-butler:
+
+Butler datasets
+===============
+
+Input datasets
+--------------
+
+:lsst-config-field:`~lsst.verify.tasks.commonMetrics.MemoryMetricConfig.metadata`
+    The metadata of the top-level command-line task (e.g., ``ProcessCcdTask``, ``ApPipeTask``) being instrumented.
+    Because the metadata produced by each top-level task is a different Butler dataset type, this dataset **must** be explicitly configured when running ``MemoryMetricTask`` or a :lsst-task:`~lsst.verify.gen2tasks.MetricsControllerTask` that contains it.
+
+.. _lsst.verify.tasks.MemoryMetricTask-subtasks:
+
+Retargetable subtasks
+=====================
+
+.. lsst-task-config-subtasks:: lsst.verify.tasks.commonMetrics.MemoryMetricTask
+
+.. _lsst.verify.tasks.MemoryMetricTask-configs:
+
+Configuration fields
+====================
+
+.. lsst-task-config-fields:: lsst.verify.tasks.commonMetrics.MemoryMetricTask
+
+.. _lsst.verify.tasks.MemoryMetricTask-examples:
+
+Examples
+========
+
+.. code-block:: py
+
+   from lsst.verify.tasks import MemoryMetricTask
+
+   config = MemoryMetricTask.ConfigClass()
+   config.metadata.name = "apPipe_metadata"
+   config.target = "apPipe:ccdProcessor.runDataRef"
+   config.metric = "pipe_tasks.ProcessCcdMemory"
+   task = MemoryMetricTask(config=config)
+
+   # config.metadata provided for benefit of MetricsControllerTask/Pipeline
+   # but since we've defined it we might as well use it
+   metadata = butler.get(config.metadata.name)
+   processCcdTime = task.run(metadata).measurement

--- a/doc/lsst.verify/tasks/lsst.verify.tasks.MemoryMetricTask.rst
+++ b/doc/lsst.verify/tasks/lsst.verify.tasks.MemoryMetricTask.rst
@@ -7,6 +7,11 @@ MemoryMetricTask
 ``MemoryMetricTask`` creates a resident set size `~lsst.verify.Measurement` based on data collected by @\ `~lsst.pipe.base.timeMethod`.
 It reads the raw timing data from the top-level `~lsst.pipe.base.CmdLineTask`'s metadata, which is identified by the task configuration.
 
+In general, it's only useful to measure this metric for the top-level task being run.
+@\ `~lsst.pipe.base.timeMethod` measures the peak memory usage from process start, so the results for any subtask will be contaminated by previous subtasks run on the same data ID.
+
+Because @\ `~lsst.pipe.base.timeMethod` gives platform-dependent results, this task may give incorrect results (e.g., units) when run in a distributed system with heterogeneous nodes.
+
 .. _lsst.verify.tasks.MemoryMetricTask-summary:
 
 Processing summary

--- a/doc/lsst.verify/tasks/lsst.verify.tasks.TimingMetricTask.rst
+++ b/doc/lsst.verify/tasks/lsst.verify.tasks.TimingMetricTask.rst
@@ -61,7 +61,7 @@ Examples
    config.metadata.name = "apPipe_metadata"
    config.target = "apPipe:ccdProcessor.runDataRef"
    config.metric = "pipe_tasks.ProcessCcdTime"
-   task = TimingMetricTask(config)
+   task = TimingMetricTask(config=config)
 
    # config.metadata provided for benefit of MetricsControllerTask/Pipeline
    # but since we've defined it we might as well use it

--- a/python/lsst/verify/measurement.py
+++ b/python/lsst/verify/measurement.py
@@ -200,8 +200,10 @@ class Measurement(JsonSerializationMixin):
             # check unit consistency
             if not self.metric.check_unit(q):
                 message = ("The quantity's units {0} are incompatible with "
-                           "the metric's units {1}")
-                raise TypeError(message.format(q.unit, self.metric.unit))
+                           "{1}'s units {2}")
+                raise TypeError(message.format(q.unit,
+                                               self.metric_name,
+                                               self.metric.unit))
 
         self._quantity = q
 

--- a/python/lsst/verify/tasks/commonMetrics.py
+++ b/python/lsst/verify/tasks/commonMetrics.py
@@ -35,17 +35,24 @@ from lsst.verify.gen2tasks.metricRegistry import registerMultiple
 from lsst.verify.tasks import MetricComputationError, MetadataMetricTask
 
 
-class TimingMetricConfig(MetadataMetricTask.ConfigClass):
-    """Information that distinguishes one timing metric from another.
+class TimeMethodMetricConfig(MetadataMetricTask.ConfigClass):
+    """Common config fields for metrics based on `~lsst.pipe.base.timeMethod`.
+
+    These fields let metrics distinguish between different methods that have
+    been decorated with `~lsst.pipe.base.timeMethod`.
     """
     target = pexConfig.Field(
         dtype=str,
-        doc="The method to time, optionally prefixed by one or more tasks "
+        doc="The method to profile, optionally prefixed by one or more tasks "
             "in the format of `lsst.pipe.base.Task.getFullMetadata()`.")
     metric = pexConfig.Field(
         dtype=str,
         doc="The fully qualified name of the metric to store the "
-            "timing information.")
+            "profiling information.")
+
+
+# Expose TimingMetricConfig name because config-writers expect it
+TimingMetricConfig = TimeMethodMetricConfig
 
 
 @registerMultiple("timing")

--- a/python/lsst/verify/tasks/commonMetrics.py
+++ b/python/lsst/verify/tasks/commonMetrics.py
@@ -106,7 +106,7 @@ class TimingMetricTask(MetadataMetricTask):
         Returns
         -------
         measurement : `lsst.verify.Measurement` or `None`
-            The the total running time of the target method across all
+            The total running time of the target method across all
             elements of ``metadata``.
 
         Raises

--- a/python/lsst/verify/tasks/commonMetrics.py
+++ b/python/lsst/verify/tasks/commonMetrics.py
@@ -24,7 +24,12 @@
 """Code for measuring metrics that apply to any Task.
 """
 
-__all__ = ["TimingMetricConfig", "TimingMetricTask"]
+__all__ = ["TimingMetricConfig", "TimingMetricTask",
+           "MemoryMetricConfig", "MemoryMetricTask",
+           ]
+
+import resource
+import sys
 
 import astropy.units as u
 
@@ -148,6 +153,125 @@ class TimingMetricTask(MetadataMetricTask):
             self.log.info("Nothing to do: no timing information for %s found.",
                           self.config.target)
             return None
+
+    @classmethod
+    def getOutputMetricName(cls, config):
+        return Name(config.metric)
+
+
+# Expose MemoryMetricConfig name because config-writers expect it
+MemoryMetricConfig = TimeMethodMetricConfig
+
+
+@registerMultiple("memory")
+class MemoryMetricTask(MetadataMetricTask):
+    """A Task that computes the maximum resident set size using metadata
+    produced by the `lsst.pipe.base.timeMethod` decorator.
+
+    Parameters
+    ----------
+    args
+    kwargs
+        Constructor parameters are the same as for
+        `lsst.verify.gen2tasks.MetricTask`.
+    """
+
+    ConfigClass = MemoryMetricConfig
+    _DefaultName = "memoryMetric"
+
+    @classmethod
+    def getInputMetadataKeys(cls, config):
+        """Get search strings for the metadata.
+
+        Parameters
+        ----------
+        config : ``cls.ConfigClass``
+            Configuration for this task.
+
+        Returns
+        -------
+        keys : `dict`
+            A dictionary of keys, optionally prefixed by one or more tasks in
+            the format of `lsst.pipe.base.Task.getFullMetadata()`.
+
+             ``"EndMemory"``
+                 The key for the memory usage at the end of the method (`str`).
+        """
+        keyBase = config.target
+        return {"EndMemory": keyBase + "EndMaxResidentSetSize"}
+
+    def makeMeasurement(self, memory):
+        """Compute a maximum resident set size measurement from metadata
+        provided by `lsst.pipe.base.timeMethod`.
+
+        Parameters
+        ----------
+        memory : sequence [`dict` [`str`, any]]
+            A list where each element corresponds to a metadata object passed
+            to `run`. Each `dict` has the following keys:
+
+             ``"EndMemory"``
+                 The memory usage at the end of the method (`int` or `None`).
+
+        Returns
+        -------
+        measurement : `lsst.verify.Measurement` or `None`
+            The maximum memory usage of the target method over all
+            elements of ``metadata``.
+
+        Raises
+        ------
+        MetricComputationError
+            Raised if the memory metadata are invalid.
+
+        Notes
+        -----
+        This method does not return a measurement if no memory information was
+        provided by any of the metadata.
+        """
+        maxMemory = 0.0
+        for singleRun in memory:
+            if singleRun["EndMemory"] is not None:
+                try:
+                    maxMemory = max(maxMemory, singleRun["EndMemory"])
+                except TypeError as e:
+                    raise MetricComputationError("Invalid metadata") from e
+            # If None, assume the method was not run that time
+
+        if maxMemory > 0.0:
+            meas = Measurement(self.getOutputMetricName(self.config),
+                               self._addUnits(maxMemory))
+            meas.notes['estimator'] = 'pipe.base.timeMethod'
+            return meas
+        else:
+            self.log.info("Nothing to do: no memory information for %s found.",
+                          self.config.target)
+            return None
+
+    def _addUnits(self, memory):
+        """Represent memory usage in correct units.
+
+        Parameters
+        ----------
+        memory : `int`
+            The memory usage as returned by `resource.getrusage`, in
+            platform-dependent units.
+
+        Returns
+        -------
+        memory : `astropy.units.Quantity`
+            The memory usage in absolute units.
+        """
+        if sys.platform.startswith('darwin'):
+            # MacOS uses bytes
+            return memory * u.byte
+        elif sys.platform.startswith('sunos') \
+                or sys.platform.startswith('solaris'):
+            # Solaris and SunOS use pages
+            return memory * resource.getpagesize() * u.byte
+        else:
+            # Assume Linux, which uses kibibytes
+            return memory * u.kibibyte
 
     @classmethod
     def getOutputMetricName(cls, config):

--- a/tests/test_commonMetrics.py
+++ b/tests/test_commonMetrics.py
@@ -59,9 +59,6 @@ class TimingMetricTestSuite(MetadataMetricTestCase):
         return config
 
     def setUp(self):
-        """Create a dummy instance of `FringeTask` so that test cases can
-        run and measure it.
-        """
         super().setUp()
         self.config = TimingMetricTestSuite._standardConfig()
 


### PR DESCRIPTION
This PR adds `MemoryMetricTask`, a class for computing the values of the memory metrics introduced in lsst/verify_metrics#18. It also fixes some minor bugs I found in the process.