### PR TITLE
DM-20963: inspect_job.py broken

### DIFF
--- a/python/lsst/verify/bin/inspectjob.py
+++ b/python/lsst/verify/bin/inspectjob.py
@@ -131,17 +131,12 @@ def build_argparser():
     return parser
 
 
-def main(filenames):
+def main():
     """Present all Job files.
-
-    Parameters
-    ----------
-    filenames : `list` of `str`
-        The Job files to open. Must be in JSON format.
     """
     args = build_argparser().parse_args()
     for filename in args.json_paths:
-        if len(filenames) > 1:
+        if len(args.json_paths) > 1:
             print("\n%s:" % filename)
         with open(filename) as f:
             job = Job.deserialize(**json.load(f))


### PR DESCRIPTION
This PR fixes a bug that caused `inspect_job.py` to reject all command-line arguments. I've confirmed that the new script is fully functional. I've also tested `dispatch_verify.py` and `lint_metrics.py`, and they work fine as-is.