### PR TITLE
DM-21103: Catch RuntimeErrors from getPackageDir

### DIFF
--- a/python/lsst/verify/metricset.py
+++ b/python/lsst/verify/metricset.py
@@ -95,7 +95,9 @@ class MetricSet(JsonSerializationMixin):
         try:
             # Try an EUPS package name
             package_dir = getPackageDir(package_name_or_path)
-        except LookupError:
+        except (LookupError, RuntimeError):
+            # Nominally getPackageDir raises a LookupError, but in some cases
+            # we've observed RuntimeErrors instead.
             # Try as a filesystem path instead
             package_dir = package_name_or_path
         finally:

--- a/python/lsst/verify/specset.py
+++ b/python/lsst/verify/specset.py
@@ -157,7 +157,9 @@ class SpecificationSet(JsonSerializationMixin):
         try:
             # Try an EUPS package name
             package_dir = getPackageDir(package_name_or_path)
-        except LookupError:
+        except (LookupError, RuntimeError):
+            # Nominally getPackageDir raises a LookupError, but in some cases
+            # we've observed RuntimeErrors instead.
             # Try as a filesystem path instead
             package_dir = package_name_or_path
         finally:


### PR DESCRIPTION
lsst.utils.getPackageDir normally emits a LookupError when it cannot find a package, but in the case of a user passing a string "verify_astrometry" in, it was emitting a RuntimeError instead. The handling pattern is the same either way, so this addresses that rare situation.

Not that the LookupError situation is already exercised in the unit tests. I don't know if its worth try to force a RuntimeError situation in the tests too for this.

(Re-do of #52)