### PR TITLE
DM-20974: Remove aggregation support/requirement from MetricTask

### DIFF
--- a/doc/lsst.verify/tasks/lsst.verify.gen2tasks.MetricTask.rst
+++ b/doc/lsst.verify/tasks/lsst.verify.gen2tasks.MetricTask.rst
@@ -46,7 +46,7 @@ Subclassing
 Each subclass must also implement the `~MetricTask.getOutputMetricName` method.
 
 The task config should use `lsst.pipe.base.PipelineTaskConnections` to identify input datasets as if it were a `~lsst.pipe.base.PipelineTask`.
-Only the ``name`` field is used in a Gen 2 context, but use of `~lsst.pipe.base.PipelineTaskConnections` is expected to simplify the transition to Gen 3.
+Only the ``name`` and ``multiple`` fields are used in a Gen 2 context, but use of `~lsst.pipe.base.PipelineTaskConnections` is expected to simplify the transition to Gen 3.
 
 .. _lsst.verify.gen2tasks.MetricTask-indepth-errors:
 

--- a/doc/lsst.verify/tasks/lsst.verify.tasks.MetadataMetricTask.rst
+++ b/doc/lsst.verify/tasks/lsst.verify.tasks.MetadataMetricTask.rst
@@ -4,8 +4,10 @@
 MetadataMetricTask
 ##################
 
-``MetadataMetricTask`` is a base class for generating `~lsst.verify.Measurement`\ s from task metadata.
+``MetadataMetricTask`` is a base class for generating `~lsst.verify.Measurement`\ s from task metadata of the same granularity.
 The class handles loading metadata and extracting the keys of interest, while subclasses are responsible for creating the `~lsst.verify.Measurement` from the extracted values.
+
+See :lsst-task:`~lsst.verify.tasks.MultiMetadataMetricTask` for metrics computed from several finer-grained metadata.
 
 ``MetadataMetricTask`` is currently a subclass of `lsst.verify.gen2tasks.MetricTask`.
 It is expected that ``MetadataMetricTask`` can be migrated to the Gen 3 framework without affecting its subclasses.
@@ -18,7 +20,7 @@ Processing summary
 ``MetadataMetricTask`` runs this sequence of operations:
 
 #. Find the metadata key(s) needed to compute the metric by calling the customizable `~lsst.verify.tasks.MetadataMetricTask.getInputMetadataKeys` method.
-#. Search all the metadata objects passed to `~lsst.verify.tasks.MetadataMetricTask.run` for the keys, and extract the corresponding values.
+#. Search the metadata object passed to `~lsst.verify.tasks.MetadataMetricTask.run` for the keys, and extract the corresponding values.
 #. Process the values by calling the customizable `~lsst.verify.tasks.MetadataMetricTask.makeMeasurement` method, and return the `~lsst.verify.Measurement`.
 
 .. _lsst.verify.tasks.MetadataMetricTask-api:

--- a/doc/lsst.verify/tasks/lsst.verify.tasks.MultiMetadataMetricTask.rst
+++ b/doc/lsst.verify/tasks/lsst.verify.tasks.MultiMetadataMetricTask.rst
@@ -1,0 +1,57 @@
+.. lsst-task-topic:: lsst.verify.tasks.MultiMetadataMetricTask
+
+#######################
+MultiMetadataMetricTask
+#######################
+
+``MultiMetadataMetricTask`` is a base class for generating `~lsst.verify.Measurement`\ s from task metadata of a higher granularity than the metric.
+The class handles loading metadata and extracting the keys of interest, while subclasses are responsible for creating the `~lsst.verify.Measurement` from the extracted values.
+
+See :lsst-task:`~lsst.verify.tasks.MetadataMetricTask` for when the metadata and metric have the same granularity.
+
+``MultiMetadataMetricTask`` is currently a subclass of `lsst.verify.gen2tasks.MetricTask`.
+It is expected that ``MultiMetadataMetricTask`` can be migrated to the Gen 3 framework without affecting its subclasses.
+
+.. _lsst.verify.tasks.MultiMetadataMetricTask-summary:
+
+Processing summary
+==================
+
+``MultiMetadataMetricTask`` runs this sequence of operations:
+
+#. Find the metadata key(s) needed to compute the metric by calling the customizable `~lsst.verify.tasks.MultiMetadataMetricTask.getInputMetadataKeys` method.
+#. Search all the metadata objects passed to `~lsst.verify.tasks.MultiMetadataMetricTask.run` for the keys, and extract the corresponding values.
+#. Process the values by calling the customizable `~lsst.verify.tasks.MultiMetadataMetricTask.makeMeasurement` method, and return the `~lsst.verify.Measurement`.
+
+.. _lsst.verify.tasks.MultiMetadataMetricTask-api:
+
+Python API summary
+==================
+
+.. lsst-task-api-summary:: lsst.verify.tasks.MultiMetadataMetricTask
+
+.. _lsst.verify.tasks.MultiMetadataMetricTask-butler:
+
+Butler datasets
+===============
+
+Input datasets
+--------------
+
+:lsst-config-field:`~lsst.verify.tasks.MultiMetadataMetricTask.MetadataMetricConfig.metadata`
+    The metadata of the top-level command-line task (e.g., ``ProcessCcdTask``, ``ApPipeTask``) being instrumented.
+    Because the metadata produced by each top-level task is a different Butler dataset type, this dataset **must** be explicitly configured when running ``MultiMetadataMetricTask`` or a :lsst-task:`~lsst.verify.gen2tasks.MetricsControllerTask` that contains it.
+
+.. _lsst.verify.tasks.MultiMetadataMetricTask-subtasks:
+
+Retargetable subtasks
+=====================
+
+.. lsst-task-config-subtasks:: lsst.verify.tasks.MultiMetadataMetricTask
+
+.. _lsst.verify.tasks.MultiMetadataMetricTask-configs:
+
+Configuration fields
+====================
+
+.. lsst-task-config-fields:: lsst.verify.tasks.MultiMetadataMetricTask

--- a/python/lsst/verify/gen2tasks/metricsControllerTask.py
+++ b/python/lsst/verify/gen2tasks/metricsControllerTask.py
@@ -151,13 +151,19 @@ class MetricsControllerTask(Task):
         """
         self.log.debug("Running %s on %r", type(metricTask), dataref)
         inputTypes = metricTask.getInputDatasetTypes(metricTask.config)
+        inputScalars = metricTask.areInputDatasetsScalar(metricTask.config)
         inputData = {}
         inputDataIds = {}
-        for param, dataType in inputTypes.items():
+        for (param, dataType), scalar \
+                in zip(inputTypes.items(), inputScalars.values()):
             inputRefs = dafPersist.searchDataRefs(
                 dataref.getButler(), dataType, dataId=dataref.dataId)
-            inputData[param] = [ref.get() for ref in inputRefs]
-            inputDataIds[param] = [ref.dataId for ref in inputRefs]
+            if scalar:
+                inputData[param] = inputRefs[0].get() if inputRefs else None
+                inputDataIds[param] = inputRefs[0].dataId if inputRefs else {}
+            else:
+                inputData[param] = [ref.get() for ref in inputRefs]
+                inputDataIds[param] = [ref.dataId for ref in inputRefs]
 
         outputDataIds = {"measurement": dataref.dataId}
         try:

--- a/python/lsst/verify/gen2tasks/testUtils.py
+++ b/python/lsst/verify/gen2tasks/testUtils.py
@@ -107,14 +107,16 @@ class MetricTaskTestCase(lsst.utils.tests.TestCase, metaclass=abc.ABCMeta):
                 addStandardMetadata=unittest.mock.DEFAULT) as mockDict:
             mockDict['run'].return_value = Struct(measurement=dummy)
 
-            inputTypes = self.taskClass.getInputDatasetTypes(self.task.config)
-            inputParams = inputTypes.keys()
+            inputScalars = self.taskClass.areInputDatasetsScalar(
+                self.task.config)
             # Probably won't satisfy all adaptArgsAndRun specs,
             # but hopefully works with most of them
             dataId = {}
             result = self.task.adaptArgsAndRun(
-                {key: [None] for key in inputParams},
-                {key: [dataId] for key in inputParams},
+                {key: (None if scalar else [None])
+                    for key, scalar in inputScalars.items()},
+                {key: (dataId if scalar else [dataId])
+                    for key, scalar in inputScalars.items()},
                 {'measurement': dataId})
             mockDict['addStandardMetadata'].assert_called_once_with(
                 self.task, result.measurement, dataId)

--- a/python/lsst/verify/tasks/metadataMetricTask.py
+++ b/python/lsst/verify/tasks/metadataMetricTask.py
@@ -49,8 +49,8 @@ class MetadataMetricConfig(MetricTask.ConfigClass,
     Notes
     -----
     `MetadataMetricTask` classes that have CCD-level granularity can use
-    this class as-is. Classes representing metrics of a different granularity
-    should use `setDefaults` to override ``metadata.dimensions``.
+    this class as-is. Support for metrics of a different granularity
+    may be added later.
     """
     pass
 

--- a/python/lsst/verify/tasks/metadataMetricTask.py
+++ b/python/lsst/verify/tasks/metadataMetricTask.py
@@ -19,7 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-__all__ = ["MetadataMetricTask", "MetadataMetricConfig"]
+__all__ = ["MetadataMetricTask", "MetadataMetricConfig",
+           "MultiMetadataMetricTask", "MultiMetadataMetricConfig"]
 
 import abc
 
@@ -28,9 +29,23 @@ from lsst.verify.gen2tasks import MetricTask
 from lsst.verify.tasks import MetricComputationError
 
 
-class MetadataMetricConnections(
+class SingleMetadataMetricConnections(
         PipelineTaskConnections,
         dimensions={"Instrument", "Exposure", "Detector"},
+        defaultTemplates={"taskName": ""}):
+    metadata = connectionTypes.Input(
+        name="{taskName}_metadata",
+        doc="The target top-level task's metadata. The name must be set to "
+            "the metadata's butler type, such as 'processCcd_metadata'.",
+        storageClass="PropertySet",
+        dimensions={"Instrument", "Exposure", "Detector"},
+        multiple=False,
+    )
+
+
+class MultiMetadataMetricConnections(
+        PipelineTaskConnections,
+        dimensions={"Instrument", "Exposure"},
         defaultTemplates={"taskName": ""}):
     metadata = connectionTypes.Input(
         name="{taskName}_metadata",
@@ -42,8 +57,9 @@ class MetadataMetricConnections(
     )
 
 
-class MetadataMetricConfig(MetricTask.ConfigClass,
-                           pipelineConnections=MetadataMetricConnections):
+class MetadataMetricConfig(
+        MetricTask.ConfigClass,
+        pipelineConnections=SingleMetadataMetricConnections):
     """A base class for metadata metric task configs.
 
     Notes
@@ -55,8 +71,26 @@ class MetadataMetricConfig(MetricTask.ConfigClass,
     pass
 
 
-class MetadataMetricTask(MetricTask):
+class MultiMetadataMetricConfig(
+        MetricTask.ConfigClass,
+        pipelineConnections=MultiMetadataMetricConnections):
+    """A base class for metadata metric task configs.
+
+    Notes
+    -----
+    `MetadataMetricTask` classes that have CCD-to-visit-level granularity can
+    use this class as-is. Classes representing metrics of a different
+    granularity should override ``metadata.dimensions``
+    or ``Connections.dimensions``.
+    """
+    pass
+
+
+class _AbstractMetadataMetricTask(MetricTask):
     """A base class for tasks that compute metrics from metadata values.
+
+    This class contains code that is agnostic to whether the input is one
+    metadata object or many.
 
     Parameters
     ----------
@@ -81,8 +115,6 @@ class MetadataMetricTask(MetricTask):
     # important than ensuring that no implementation details of MetricTask
     # can leak into application-specific code.
 
-    ConfigClass = MetadataMetricConfig
-
     @classmethod
     @abc.abstractmethod
     def getInputMetadataKeys(cls, config):
@@ -102,38 +134,6 @@ class MetadataMetricTask(MetricTask):
             format of `lsst.pipe.base.Task.getFullMetadata()`. This method may
             return a substring of the desired (full) key, but multiple matches
             for any key will cause an error.
-        """
-
-    @abc.abstractmethod
-    def makeMeasurement(self, values):
-        """Compute the metric given the values of the metadata.
-
-        Parameters
-        ----------
-        values : sequence [`dict` [`str`, any]]
-            A list where each element corresponds to a metadata object passed
-            to `run`. Each `dict` has the same keys as returned by
-            `getInputMetadataKeys`, and maps them to the values extracted from
-            the metadata. Any value may be `None` to represent missing data.
-
-        Returns
-        -------
-        measurement : `lsst.verify.Measurement` or `None`
-            The measurement corresponding to the input data.
-
-        Raises
-        ------
-        lsst.verify.tasks.MetricComputationError
-            Raised if an algorithmic or system error prevents calculation of
-            the metric. See `adaptArgsAndRun` for expected behavior.
-
-        Notes
-        -----
-        As with all `lsst.verify.gen2tasks.MetricTask` subclasses, this method
-        should assume a many-to-one relationship between input data and the
-        resulting metric, i.e., it should not assume that the output metric
-        and the input data have the same granularity. In the common case that
-        they do, ``values`` will contain only one element.
         """
 
     @staticmethod
@@ -196,6 +196,160 @@ class MetadataMetricTask(MetricTask):
                 raise MetricComputationError(error)
         return data
 
+
+class MetadataMetricTask(_AbstractMetadataMetricTask):
+    """A base class for tasks that compute metrics from single metadata objects.
+
+    Parameters
+    ----------
+    *args
+    **kwargs
+        Constructor parameters are the same as for
+        `lsst.pipe.base.PipelineTask`.
+
+    See also
+    --------
+    MultiMetadataMetricTask
+
+    Notes
+    -----
+    This class should be customized by overriding `getInputMetadataKeys`,
+    `makeMeasurement`, and `getOutputMetricName`. You should not need to
+    override `run`.
+
+    This class makes no assumptions about how to handle missing data;
+    `makeMeasurement` may be called with `None` values, and is responsible
+    for deciding how to deal with them.
+    """
+    # Design note: getInputMetadataKeys and makeMeasurement are overrideable
+    # methods rather than subtask(s) to keep the configs for
+    # `MetricsControllerTask` as simple as possible. This was judged more
+    # important than ensuring that no implementation details of MetricTask
+    # can leak into application-specific code.
+
+    ConfigClass = MetadataMetricConfig
+
+    @abc.abstractmethod
+    def makeMeasurement(self, values):
+        """Compute the metric given the values of the metadata.
+
+        Parameters
+        ----------
+        values : `dict` [`str`, any]
+            A `dict` representation of the metadata passed to `run`. It has the
+            same keys as returned by `getInputMetadataKeys`, and maps them to
+            the values extracted from the metadata. Any value may be `None` to
+            represent missing data.
+
+        Returns
+        -------
+        measurement : `lsst.verify.Measurement` or `None`
+            The measurement corresponding to the input data.
+
+        Raises
+        ------
+        lsst.verify.tasks.MetricComputationError
+            Raised if an algorithmic or system error prevents calculation of
+            the metric. See `adaptArgsAndRun` for expected behavior.
+        """
+
+    def run(self, metadata):
+        """Compute a measurement from science task metadata.
+
+        Parameters
+        ----------
+        metadata : `lsst.daf.base.PropertySet` or `None`
+            A metadata object for the unit of science processing to use for
+            this metric, or a collection of such objects if this task combines
+            many units of processing into a single metric.
+
+        Returns
+        -------
+        result : `lsst.pipe.base.Struct`
+            A `~lsst.pipe.base.Struct` containing the following component:
+
+            - ``measurement``: the value of the metric
+              (`lsst.verify.Measurement` or `None`)
+
+        Raises
+        ------
+        lsst.verify.tasks.MetricComputationError
+            Raised if the strings returned by `getInputMetadataKeys` match
+            more than one key in any metadata object.
+
+        Notes
+        -----
+        This implementation calls `getInputMetadataKeys`, then searches for
+        matching keys in each metadata. It then passes the values of these
+        keys (or `None` if no match) to `makeMeasurement`, and returns its
+        result to the caller.
+        """
+        metadataKeys = self.getInputMetadataKeys(self.config)
+
+        if metadata is not None:
+            data = self._extractMetadata(metadata, metadataKeys)
+        else:
+            data = {dataName: None for dataName in metadataKeys}
+
+        return Struct(measurement=self.makeMeasurement(data))
+
+
+class MultiMetadataMetricTask(_AbstractMetadataMetricTask):
+    """A base class for tasks that compute metrics from multiple metadata objects.
+
+    Parameters
+    ----------
+    *args
+    **kwargs
+        Constructor parameters are the same as for
+        `lsst.pipe.base.PipelineTask`.
+
+    See also
+    --------
+    MetadataMetricTask
+
+    Notes
+    -----
+    This class should be customized by overriding `getInputMetadataKeys`,
+    `makeMeasurement`, and `getOutputMetricName`. You should not need to
+    override `run`.
+
+    This class makes no assumptions about how to handle missing data;
+    `makeMeasurement` may be called with `None` values, and is responsible
+    for deciding how to deal with them.
+    """
+    # Design note: getInputMetadataKeys and makeMeasurement are overrideable
+    # methods rather than subtask(s) to keep the configs for
+    # `MetricsControllerTask` as simple as possible. This was judged more
+    # important than ensuring that no implementation details of MetricTask
+    # can leak into application-specific code.
+
+    ConfigClass = MultiMetadataMetricConfig
+
+    @abc.abstractmethod
+    def makeMeasurement(self, values):
+        """Compute the metric given the values of the metadata.
+
+        Parameters
+        ----------
+        values : sequence [`dict` [`str`, any]]
+            A list where each element corresponds to a metadata object passed
+            to `run`. Each `dict` has the same keys as returned by
+            `getInputMetadataKeys`, and maps them to the values extracted from
+            the metadata. Any value may be `None` to represent missing data.
+
+        Returns
+        -------
+        measurement : `lsst.verify.Measurement` or `None`
+            The measurement corresponding to the input data.
+
+        Raises
+        ------
+        lsst.verify.tasks.MetricComputationError
+            Raised if an algorithmic or system error prevents calculation of
+            the metric. See `adaptArgsAndRun` for expected behavior.
+        """
+
     def run(self, metadata):
         """Compute a measurement from science task metadata.
 
@@ -223,9 +377,9 @@ class MetadataMetricTask(MetricTask):
         Notes
         -----
         This implementation calls `getInputMetadataKeys`, then searches for
-        matching keys in each element of ``metadata``. It then passes the
-        values of these keys (or `None` if no match) to `makeMeasurement`, and
-        returns its result to the caller.
+        matching keys in each metadata. It then passes the values of these
+        keys (or `None` if no match) to `makeMeasurement`, and returns its
+        result to the caller.
         """
         metadataKeys = self.getInputMetadataKeys(self.config)
 

--- a/python/lsst/verify/tasks/ppdbMetricTask.py
+++ b/python/lsst/verify/tasks/ppdbMetricTask.py
@@ -284,10 +284,7 @@ class PpdbMetricTask(MetricTask):
 
             ``"dbInfo"``
                 The dataset (of the type indicated by `getInputDatasetTypes`)
-                from which to load the database. A single-element list
-                containing a dataset is allowed for compatibility with
-                `~lsst.verify.gen2tasks.MetricsControllerTask`, but should
-                otherwise not be used.
+                from which to load the database.
         inputDataIds : `dict` [`str`, data ID]
             Dictionary with one key:
 
@@ -328,10 +325,6 @@ class PpdbMetricTask(MetricTask):
         """
         dataId = outputDataId["measurement"]
         dbInfo = inputData["dbInfo"]
-        try:
-            dbInfo = dbInfo[0]
-        except TypeError:
-            pass
 
         db = self.dbLoader.run(dbInfo).ppdb
 

--- a/tests/test_commonMetrics.py
+++ b/tests/test_commonMetrics.py
@@ -67,7 +67,7 @@ class TimingMetricTestSuite(MetadataMetricTestCase):
         self.scienceTask.run()
 
     def testValid(self):
-        result = self.task.run([self.scienceTask.getFullMetadata()])
+        result = self.task.run(self.scienceTask.getFullMetadata())
         meas = result.measurement
 
         self.assertIsInstance(meas, Measurement)
@@ -79,22 +79,17 @@ class TimingMetricTestSuite(MetadataMetricTestCase):
         self.config.metric = "foo.bar.FooBarTime"
         task = TimingMetricTask(config=self.config)
         with self.assertRaises(TypeError):
-            task.run([self.scienceTask.getFullMetadata()])
+            task.run(self.scienceTask.getFullMetadata())
 
     def testMissingData(self):
-        result = self.task.run([None])
-        meas = result.measurement
-        self.assertIsNone(meas)
-
-    def testNoDataExpected(self):
-        result = self.task.run([])
+        result = self.task.run(None)
         meas = result.measurement
         self.assertIsNone(meas)
 
     def testRunDifferentMethod(self):
         self.config.target = DummyTask._DefaultName + ".runDataRef"
         task = TimingMetricTask(config=self.config)
-        result = task.run([self.scienceTask.getFullMetadata()])
+        result = task.run(self.scienceTask.getFullMetadata())
         meas = result.measurement
         self.assertIsNone(meas)
 
@@ -108,7 +103,7 @@ class TimingMetricTestSuite(MetadataMetricTestCase):
 
         task = TimingMetricTask(config=self.config)
         with self.assertRaises(MetricComputationError):
-            task.run([metadata])
+            task.run(metadata)
 
     def testBadlyTypedKeys(self):
         metadata = self.scienceTask.getFullMetadata()
@@ -120,7 +115,7 @@ class TimingMetricTestSuite(MetadataMetricTestCase):
 
         task = TimingMetricTask(config=self.config)
         with self.assertRaises(MetricComputationError):
-            task.run([metadata])
+            task.run(metadata)
 
     def testGetInputDatasetTypes(self):
         types = TimingMetricTask.getInputDatasetTypes(self.config)
@@ -130,28 +125,14 @@ class TimingMetricTestSuite(MetadataMetricTestCase):
 
     def testFineGrainedMetric(self):
         metadata = self.scienceTask.getFullMetadata()
-        inputData = {"metadata": [metadata]}
-        inputDataIds = {"metadata": [{"visit": 42, "ccd": 1}]}
+        inputData = {"metadata": metadata}
+        inputDataIds = {"metadata": {"visit": 42, "ccd": 1}}
         outputDataId = {"measurement": {"visit": 42, "ccd": 1}}
-        measDirect = self.task.run([metadata]).measurement
+        measDirect = self.task.run(metadata).measurement
         measIndirect = self.task.adaptArgsAndRun(
             inputData, inputDataIds, outputDataId).measurement
 
         assert_quantity_allclose(measIndirect.quantity, measDirect.quantity)
-
-    def testCoarseGrainedMetric(self):
-        metadata = self.scienceTask.getFullMetadata()
-        nCcds = 3
-        inputData = {"metadata": [metadata] * nCcds}
-        inputDataIds = {"metadata": [{"visit": 42, "ccd": x}
-                                     for x in range(nCcds)]}
-        outputDataId = {"measurement": {"visit": 42}}
-        measDirect = self.task.run([metadata]).measurement
-        measMany = self.task.adaptArgsAndRun(
-            inputData, inputDataIds, outputDataId).measurement
-
-        assert_quantity_allclose(measMany.quantity,
-                                 nCcds * measDirect.quantity)
 
     def testGetOutputMetricName(self):
         self.assertEqual(TimingMetricTask.getOutputMetricName(self.config),
@@ -179,7 +160,7 @@ class MemoryMetricTestSuite(MetadataMetricTestCase):
         self.scienceTask.run()
 
     def testValid(self):
-        result = self.task.run([self.scienceTask.getFullMetadata()])
+        result = self.task.run(self.scienceTask.getFullMetadata())
         meas = result.measurement
 
         self.assertIsInstance(meas, Measurement)
@@ -190,22 +171,17 @@ class MemoryMetricTestSuite(MetadataMetricTestCase):
         self.config.metric = "foo.bar.FooBarMemory"
         task = MemoryMetricTask(config=self.config)
         with self.assertRaises(TypeError):
-            task.run([self.scienceTask.getFullMetadata()])
+            task.run(self.scienceTask.getFullMetadata())
 
     def testMissingData(self):
-        result = self.task.run([None])
-        meas = result.measurement
-        self.assertIsNone(meas)
-
-    def testNoDataExpected(self):
-        result = self.task.run([])
+        result = self.task.run(None)
         meas = result.measurement
         self.assertIsNone(meas)
 
     def testRunDifferentMethod(self):
         self.config.target = DummyTask._DefaultName + ".runDataRef"
         task = MemoryMetricTask(config=self.config)
-        result = task.run([self.scienceTask.getFullMetadata()])
+        result = task.run(self.scienceTask.getFullMetadata())
         meas = result.measurement
         self.assertIsNone(meas)
 
@@ -219,7 +195,7 @@ class MemoryMetricTestSuite(MetadataMetricTestCase):
 
         task = MemoryMetricTask(config=self.config)
         with self.assertRaises(MetricComputationError):
-            task.run([metadata])
+            task.run(metadata)
 
     def testGetInputDatasetTypes(self):
         types = MemoryMetricTask.getInputDatasetTypes(self.config)
@@ -229,28 +205,14 @@ class MemoryMetricTestSuite(MetadataMetricTestCase):
 
     def testFineGrainedMetric(self):
         metadata = self.scienceTask.getFullMetadata()
-        inputData = {"metadata": [metadata]}
-        inputDataIds = {"metadata": [{"visit": 42, "ccd": 1}]}
+        inputData = {"metadata": metadata}
+        inputDataIds = {"metadata": {"visit": 42, "ccd": 1}}
         outputDataId = {"measurement": {"visit": 42, "ccd": 1}}
-        measDirect = self.task.run([metadata]).measurement
+        measDirect = self.task.run(metadata).measurement
         measIndirect = self.task.adaptArgsAndRun(
             inputData, inputDataIds, outputDataId).measurement
 
         assert_quantity_allclose(measIndirect.quantity, measDirect.quantity)
-
-    def testCoarseGrainedMetric(self):
-        metadata = self.scienceTask.getFullMetadata()
-        nCcds = 3
-        inputData = {"metadata": [metadata] * nCcds}
-        inputDataIds = {"metadata": [{"visit": 42, "ccd": x}
-                                     for x in range(nCcds)]}
-        outputDataId = {"measurement": {"visit": 42}}
-        measDirect = self.task.run([metadata]).measurement
-        measMany = self.task.adaptArgsAndRun(
-            inputData, inputDataIds, outputDataId).measurement
-
-        # Aggregated metric takes the max, so no change
-        assert_quantity_allclose(measMany.quantity, measDirect.quantity)
 
     def testGetOutputMetricName(self):
         self.assertEqual(MemoryMetricTask.getOutputMetricName(self.config),

--- a/tests/test_metricsController.py
+++ b/tests/test_metricsController.py
@@ -86,6 +86,10 @@ class _DemoMetricTask(MetricTask):
         return {'inputData': "metadata"}
 
     @classmethod
+    def areInputDatasetsScalar(cls, _config):
+        return {'inputData': False}
+
+    @classmethod
     def getOutputMetricName(cls, config):
         return Name(config.metric)
 
@@ -107,6 +111,10 @@ class _RepeatedMetricTask(MetricTask):
     @classmethod
     def getInputDatasetTypes(cls, _config):
         return {'inputData': "metadata"}
+
+    @classmethod
+    def areInputDatasetsScalar(cls, _config):
+        return {'inputData': False}
 
     @classmethod
     def getOutputMetricName(cls, config):


### PR DESCRIPTION
This PR adds a method to `gen2tasks.MetricTask` that lets it specify whether it takes scalar or vector input, and modifies `MetricsControllerTask` to check it. All `MetricTask`s have been converted to take scalar inputs, except for the abstract `MetadataMetricTask`, which has been split into both a scalar and a vector version (`MetadataMetricTask` and `MultiMetadataMetricTask`, respectively).