### PR TITLE
DM-21877: Create "marker" Butler dataset for PPDB

### DIFF
--- a/doc/lsst.verify/tasks/lsst.verify.tasks.ApdbMetricTask.rst
+++ b/doc/lsst.verify/tasks/lsst.verify.tasks.ApdbMetricTask.rst
@@ -17,8 +17,8 @@ Processing summary
 
 ``ApdbMetricTask`` runs this sequence of operations:
 
-#. Load the dataset indicated by :lsst-config-field:`~lsst.verify.tasks.apdbMetricTask.ApdbMetricConfig.dbInfo` (default: the top-level science task's config).
-#. Generate an `~lsst.dax.apdb.Apdb` object by calling the :lsst-config-field:`~lsst.verify.tasks.apdbMetricTask.ApdbMetricConfig.dbLoader` subtask (default: :lsst-task:`~lsst.verify.tasks.apdbMetricTask.ConfigApdbLoader`).
+#. Load the dataset indicated by :lsst-config-field:`~lsst.verify.tasks.apdbMetricTask.ApdbMetricConfig.dbInfo` (default: one or more ``apdb_marker`` datasets).
+#. Generate an `~lsst.dax.apdb.Apdb` object by calling the :lsst-config-field:`~lsst.verify.tasks.apdbMetricTask.ApdbMetricConfig.dbLoader` subtask (default: :lsst-task:`~lsst.verify.tasks.apdbMetricTask.DirectApdbLoader`).
 #. Process the database by passing it to the customizable `~lsst.verify.tasks.apdbMetricTask.ApdbMetricTask.makeMeasurement` method, and return the `~lsst.verify.Measurement`.
 
 .. _lsst.verify.tasks.ApdbMetricTask-api:
@@ -38,8 +38,8 @@ Input datasets
 
 :lsst-config-field:`~lsst.verify.tasks.apdbMetricTask.ApdbMetricConfig.dbInfo`
     The Butler dataset from which the database connection can be initialized.
-    The type must match the input required by the :lsst-config-field:`~lsst.verify.tasks.apdbMetricTask.ApdbMetricConfig.dbLoader` subtask (default: the top-level science task's config).
-    If the input is a config, its name **must** be explicitly configured when running ``ApdbMetricTask`` or a :lsst-task:`~lsst.verify.gen2tasks.MetricsControllerTask` that contains it.
+    The type must match the input required by the :lsst-config-field:`~lsst.verify.tasks.apdbMetricTask.ApdbMetricConfig.dbLoader` subtask (default: ``apdb_marker``).
+    If the input is a task config, its name **must** be explicitly configured when running ``ApdbMetricTask`` or a :lsst-task:`~lsst.verify.gen2tasks.MetricsControllerTask` that contains it.
 
 .. _lsst.verify.tasks.ApdbMetricTask-subtasks:
 

--- a/doc/lsst.verify/tasks/lsst.verify.tasks.DirectApdbLoader.rst
+++ b/doc/lsst.verify/tasks/lsst.verify.tasks.DirectApdbLoader.rst
@@ -1,0 +1,39 @@
+.. lsst-task-topic:: lsst.verify.tasks.apdbMetricTask.DirectApdbLoader
+
+################
+DirectApdbLoader
+################
+
+``DirectApdbLoader`` creates a `lsst.dax.apdb.Apdb` object from a `~lsst.dax.apdb.ApdbConfig`.
+This provides users with a `~lsst.dax.apdb.Apdb` object that accesses the indicated database.
+
+This task is intended for use as a subtask of :lsst-task:`lsst.verify.tasks.apdbMetricTask.ApdbMetricTask`.
+
+.. _lsst.verify.tasks.DirectApdbLoader-summary:
+
+Processing summary
+==================
+
+``DirectApdbLoader`` takes a config as input.
+It then constructs a `~lsst.dax.apdb.Apdb` object based on that config and returns it.
+
+.. _lsst.verify.tasks.DirectApdbLoader-api:
+
+Python API summary
+==================
+
+.. lsst-task-api-summary:: lsst.verify.tasks.DirectApdbLoader
+
+.. _lsst.verify.tasks.DirectApdbLoader-subtasks:
+
+Retargetable subtasks
+=====================
+
+.. lsst-task-config-subtasks:: lsst.verify.tasks.DirectApdbLoader
+
+.. _lsst.verify.tasks.DirectApdbLoader-configs:
+
+Configuration fields
+====================
+
+.. lsst-task-config-fields:: lsst.verify.tasks.DirectApdbLoader

--- a/python/lsst/verify/tasks/apdbMetricTask.py
+++ b/python/lsst/verify/tasks/apdbMetricTask.py
@@ -19,7 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-__all__ = ["ApdbMetricTask", "ApdbMetricConfig", "ConfigApdbLoader"]
+__all__ = ["ApdbMetricTask", "ApdbMetricConfig", "ConfigApdbLoader",
+           "DirectApdbLoader"]
 
 import abc
 
@@ -156,6 +157,42 @@ class ConfigApdbLoader(Task):
                 exists (`lsst.dax.apdb.Apdb` or `None`).
         """
         return Struct(apdb=self._getApdb(config))
+
+
+class DirectApdbLoader(Task):
+    """A Task that takes a Apdb config and returns the corresponding
+    Apdb object.
+
+    Parameters
+    ----------
+    *args
+    **kwargs
+        Constructor parameters are the same as for `lsst.pipe.base.Task`.
+    """
+
+    _DefaultName = "directApdb"
+    ConfigClass = Config
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def run(self, config):
+        """Create a database from a config.
+
+        Parameters
+        ----------
+        config : `lsst.dax.apdb.ApdbConfig` or `None`
+            A config for the database connection.
+
+        Returns
+        -------
+        result : `lsst.pipe.base.Struct`
+            Result struct with components:
+
+            ``apdb``
+                A database configured the same way as in ``config``.
+        """
+        return Struct(apdb=(Apdb(config) if config else None))
 
 
 class ApdbMetricConnections(

--- a/python/lsst/verify/tasks/apdbMetricTask.py
+++ b/python/lsst/verify/tasks/apdbMetricTask.py
@@ -197,7 +197,7 @@ class DirectApdbLoader(Task):
 
 class ApdbMetricConnections(
         PipelineTaskConnections,
-        dimensions=set(),
+        dimensions={"instrument"},
 ):
     dbInfo = connectionTypes.Input(
         name="apdb_marker",

--- a/python/lsst/verify/tasks/apdbMetricTask.py
+++ b/python/lsst/verify/tasks/apdbMetricTask.py
@@ -142,7 +142,7 @@ class ConfigApdbLoader(Task):
 
         Parameters
         ----------
-        config : `lsst.pex.config.Config`
+        config : `lsst.pex.config.Config` or `None`
             A config that should contain a `lsst.dax.apdb.ApdbConfig`.
             Behavior is undefined if there is more than one such member.
 
@@ -268,9 +268,9 @@ class ApdbMetricTask(MetricTask):
         -----
         This implementation calls
         `~lsst.verify.tasks.ApdbMetricConfig.dbLoader` to acquire a database
-        handle, then passes it and the value of ``outputDataId`` to
-        `makeMeasurement`. The result of `makeMeasurement` is returned to
-        the caller.
+        handle (taking `None` if no input), then passes it and the value of
+        ``outputDataId`` to `makeMeasurement`. The result of `makeMeasurement`
+        is returned to the caller.
         """
         db = self.dbLoader.run(dbInfo).apdb
 

--- a/python/lsst/verify/tasks/testUtils.py
+++ b/python/lsst/verify/tasks/testUtils.py
@@ -24,7 +24,6 @@ __all__ = ["MetadataMetricTestCase", "ApdbMetricTestCase"]
 import unittest.mock
 from unittest.mock import patch
 
-from lsst.pex.config import Config, ConfigField
 from lsst.daf.base import PropertySet
 from lsst.dax.apdb import ApdbConfig
 
@@ -114,25 +113,22 @@ class ApdbMetricTestCase(MetricTaskTestCase):
         should create that input directly.
 
         The default implementation creates a `~lsst.pex.config.Config` that
-        will be accepted by `~lsst.verify.tasks.ConfigApdbLoader`. Test suites
+        will be accepted by `~lsst.verify.tasks.DirectApdbLoader`. Test suites
         that use a different loader should override this method.
         """
-        class DummyConfig(Config):
-            apdb = ConfigField(dtype=ApdbConfig, doc="Mandatory field")
-
-        return DummyConfig()
+        return ApdbConfig()
 
     def testValidRun(self):
         info = self.makeDbInfo()
         with patch.object(self.task, "makeMeasurement") as mockWorkhorse:
-            self.task.run(info)
+            self.task.run([info])
             mockWorkhorse.assert_called_once()
 
     def testDataIdRun(self):
         info = self.makeDbInfo()
         with patch.object(self.task, "makeMeasurement") as mockWorkhorse:
             dataId = {'visit': 42}
-            self.task.run(info, outputDataId=dataId)
+            self.task.run([info], outputDataId=dataId)
             mockWorkhorse.assert_called_once_with(
                 unittest.mock.ANY, {'visit': 42})
 
@@ -141,4 +137,4 @@ class ApdbMetricTestCase(MetricTaskTestCase):
                           side_effect=MetricComputationError):
             info = self.makeDbInfo()
             with self.assertRaises(MetricComputationError):
-                self.task.run(info)
+                self.task.run([info])

--- a/tests/test_directApdbLoader.py
+++ b/tests/test_directApdbLoader.py
@@ -1,0 +1,61 @@
+# This file is part of verify.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import unittest
+
+import lsst.utils.tests
+from lsst.dax.apdb import Apdb, ApdbConfig
+
+from lsst.verify.tasks import DirectApdbLoader
+
+
+class DirectApdbLoaderTestSuite(lsst.utils.tests.TestCase):
+
+    @staticmethod
+    def _dummyApdbConfig():
+        config = ApdbConfig()
+        config.db_url = "sqlite://"     # in-memory DB
+        config.isolation_level = "READ_UNCOMMITTED"
+        return config
+
+    def setUp(self):
+        self.task = DirectApdbLoader()
+
+    def testNoConfig(self):
+        result = self.task.run(None)
+        self.assertIsNone(result.apdb)
+
+    def testValidConfig(self):
+        result = self.task.run(self._dummyApdbConfig())
+        self.assertIsInstance(result.apdb, Apdb)
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()


### PR DESCRIPTION
This PR replaces the default behavior of `PpdbMetricTask` (name change pending; see [DM-22039](https://jira.lsstcorp.org/browse/DM-22039)) from reading a science task config (which is not Gen-3-compatible) to reading the `apdb_marker` dataset introduced in lsst/obs_base#182. This change is *not* backwards compatible, as it forces the input of `PpdbMetricTask` to be vector rather than scalar.