### PR TITLE
DM-22093: Store begin/end times of ap_pipe in ap_verify

### DIFF
--- a/python/lsst/verify/tasks/commonMetrics.py
+++ b/python/lsst/verify/tasks/commonMetrics.py
@@ -138,7 +138,7 @@ class TimingMetricTask(MetadataMetricTask):
             else:
                 meas = Measurement(self.getOutputMetricName(self.config),
                                    totalTime * u.second)
-                meas.notes['estimator'] = 'pipe.base.timeMethod'
+                meas.notes["estimator"] = "pipe.base.timeMethod"
                 if timings["EndTimestamp"]:
                     meas.notes["end"] = timings["EndTimestamp"]
                 return meas

--- a/python/lsst/verify/tasks/commonMetrics.py
+++ b/python/lsst/verify/tasks/commonMetrics.py
@@ -98,7 +98,9 @@ class TimingMetricTask(MetadataMetricTask):
         """
         keyBase = config.target
         return {"StartTime": keyBase + "StartCpuTime",
-                "EndTime": keyBase + "EndCpuTime"}
+                "EndTime": keyBase + "EndCpuTime",
+                "EndTimestamp": keyBase + "EndUtc",
+                }
 
     def makeMeasurement(self, timings):
         """Compute a wall-clock measurement from metadata provided by
@@ -114,6 +116,9 @@ class TimingMetricTask(MetadataMetricTask):
                  The time the target method started (`float` or `None`).
              ``"EndTime"``
                  The time the target method ended (`float` or `None`).
+             ``"EndTimestamp"``
+                 The timestamp, in an ISO 8601-compliant format
+                 (`str` or `None`).
 
         Returns
         -------
@@ -134,6 +139,8 @@ class TimingMetricTask(MetadataMetricTask):
                 meas = Measurement(self.getOutputMetricName(self.config),
                                    totalTime * u.second)
                 meas.notes['estimator'] = 'pipe.base.timeMethod'
+                if timings["EndTimestamp"]:
+                    meas.notes["end"] = timings["EndTimestamp"]
                 return meas
         else:
             self.log.info("Nothing to do: no timing information for %s found.",


### PR DESCRIPTION
This PR adds a string completion timestamp to the metadata for all timing measurements. There are no test or documentation changes, as measurement metadata are provided "as-is" with no requirements on their availability or format.

Example output from `inspect_jobs.py`:
```
Measurements:
                      ap_pipe.ApPipeTime =  94.2989 s ({'estimator': 'pipe.base.timeMethod', 'end': '2019-11-16T00:12:02.754711'})
               pipe_tasks.ProcessCcdTime =   24.629 s ({'estimator': 'pipe.base.timeMethod', 'end': '2019-11-16T00:10:41.117107'})
                          ip_isr.IsrTime =   5.3994 s ({'estimator': 'pipe.base.timeMethod', 'end': '2019-11-16T00:10:20.938137'})
        pipe_tasks.CharacterizeImageTime =  10.0975 s ({'estimator': 'pipe.base.timeMethod', 'end': '2019-11-16T00:10:31.614739'})
```