### PR TITLE
DM-21875: Add StorageClass and Formatter support necessary to persist lsst.verify.Measurement in Gen3 repos

### DIFF
--- a/python/lsst/verify/__init__.py
+++ b/python/lsst/verify/__init__.py
@@ -41,3 +41,4 @@ from .blobset import *
 from .jobmetadata import *
 from .job import *
 from .output import *
+from . import yamlpersistance

--- a/python/lsst/verify/blobset.py
+++ b/python/lsst/verify/blobset.py
@@ -139,6 +139,17 @@ class BlobSet(JsonSerializationMixin):
         """
         return self._items.keys()
 
+    def values(self):
+        """Get a new view of the BlobSet's values.
+
+        Returns
+        ------
+        blob : iterable of `lsst.verify.Blob`
+            A collection of `~lsst.verify.Blob` objects that is updated when
+            this object changes.
+        """
+        return self._items.values()
+
     def items(self):
         """Iterate over (identifier, `Blob`) pairs in the set.
 

--- a/python/lsst/verify/measurement.py
+++ b/python/lsst/verify/measurement.py
@@ -368,7 +368,7 @@ class Measurement(JsonSerializationMixin):
         _quantity = u.Quantity(value, u.Unit(unit))
 
         instance = cls(metric, quantity=_quantity, blobs=_blobs)
-        instance._identifer = identifier  # re-wire id from serialization
+        instance._id = identifier  # re-wire id from serialization
         return instance
 
     def __eq__(self, other):

--- a/python/lsst/verify/yamlpersistance.py
+++ b/python/lsst/verify/yamlpersistance.py
@@ -96,6 +96,8 @@ def measurement_representer(dumper, measurement):
          "value": normalized_value,
          "unit": normalized_unit_str,
          "notes": dict(measurement.notes),
+         # extras included in blobs
+         "blobs": list(measurement.blobs.values()),
          },
     )
 
@@ -110,6 +112,7 @@ def measurement_constructor(loader, node):
         state["metric"],
         quantity=quantity,
         notes=state["notes"],
+        blobs=state["blobs"],
     )
     instance._id = state["identifier"]  # re-wire id from serialization
     return instance

--- a/python/lsst/verify/yamlpersistance.py
+++ b/python/lsst/verify/yamlpersistance.py
@@ -89,17 +89,22 @@ def measurement_representer(dumper, measurement):
          "identifier": measurement.identifier,
          "value": normalized_value,
          "unit": normalized_unit_str,
+         "notes": dict(measurement.notes),
          },
     )
 
 
 # Based on Measurement.deserialize
 def measurement_constructor(loader, node):
-    state = loader.construct_mapping(node)
+    state = loader.construct_mapping(node, deep=True)
 
     quantity = u.Quantity(state["value"], u.Unit(state["unit"]))
 
-    instance = Measurement(state["metric"], quantity=quantity)
+    instance = Measurement(
+        state["metric"],
+        quantity=quantity,
+        notes=state["notes"],
+    )
     instance._id = state["identifier"]  # re-wire id from serialization
     return instance
 

--- a/python/lsst/verify/yamlpersistance.py
+++ b/python/lsst/verify/yamlpersistance.py
@@ -1,0 +1,107 @@
+# This file is part of verify.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Shared code for persisting verify objects to YAML.
+
+The YAML code is centralized in one module to simplify registration code.
+"""
+
+__all__ = []  # code defined by this module only called indirectly
+
+
+import astropy.units as u
+import yaml
+
+from .measurement import Measurement
+
+
+def _getValidLoaders():
+    """Return a list of supported YAML loaders.
+
+    For YAML >= 5.1 need a different Loader for the constructor
+
+    Returns
+    -------
+    loaderList : `sequence`
+        A list of loaders that are supported by the current PyYAML version.
+    """
+    loaderList = [yaml.Loader, yaml.CLoader]
+    try:
+        loaderList.append(yaml.FullLoader)
+    except AttributeError:
+        pass
+    try:
+        loaderList.append(yaml.UnsafeLoader)
+    except AttributeError:
+        pass
+    try:
+        loaderList.append(yaml.SafeLoader)
+    except AttributeError:
+        pass
+    return loaderList
+
+
+def _registerTypes():
+    yaml.add_representer(Measurement, measurement_representer)
+
+    for loader in _getValidLoaders():
+        yaml.add_constructor(
+            "lsst.verify.Measurement", measurement_constructor, Loader=loader)
+
+
+# Based on Measurement.json, but provides self-contained representation
+def measurement_representer(dumper, measurement):
+    """Persist a Measurement as a mapping.
+    """
+    if measurement.quantity is None:
+        normalized_value = None
+        normalized_unit_str = None
+    elif measurement.metric is not None:
+        # ensure metrics are normalized to metric definition's units
+        metric = measurement.metric
+        normalized_value = measurement.quantity.to(metric.unit).value
+        normalized_unit_str = metric.unit_str
+    else:
+        normalized_value = measurement.quantity.value
+        normalized_unit_str = str(measurement.quantity.unit)
+
+    return dumper.represent_mapping(
+        "lsst.verify.Measurement",
+        {"metric": str(measurement.metric_name),
+         "identifier": measurement.identifier,
+         "value": normalized_value,
+         "unit": normalized_unit_str,
+         },
+    )
+
+
+# Based on Measurement.deserialize
+def measurement_constructor(loader, node):
+    state = loader.construct_mapping(node)
+
+    quantity = u.Quantity(state["value"], u.Unit(state["unit"]))
+
+    instance = Measurement(state["metric"], quantity=quantity)
+    instance._id = state["identifier"]  # re-wire id from serialization
+    return instance
+
+
+_registerTypes()

--- a/tests/butler_utils.py
+++ b/tests/butler_utils.py
@@ -1,0 +1,86 @@
+# This file is part of verify.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+__all__ = ["make_test_butler", "make_dataset_type"]
+
+
+from lsst.daf.butler import Butler, DatasetType
+
+
+# TODO: factor this out into a pipeline testing library
+def make_test_butler(root, data_ids):
+    """Create an empty repository with default configuration.
+
+    Parameters
+    ----------
+    root : `str`
+        The location of the root directory for the repository.
+    data_ids : `dict` [`str`, `iterable` [`dict`]]
+        A dictionary keyed by the dimensions used in the test. Each value
+        is a dictionary of fields and values for that dimension. See
+        :file:`daf/butler/config/dimensions.yaml` for required fields,
+        listed as "keys" and "requires" under each dimension's entry.
+
+    Returns
+    -------
+    butler : `lsst.daf.butler.Butler`
+        A Butler referring to the new repository.
+    """
+    # TODO: takes 5 seconds to run; split up into class-level Butler
+    #     with test-level runs after DM-21246
+    Butler.makeRepo(root)
+    butler = Butler(root, run="test")
+    for dimension, values in data_ids.items():
+        butler.registry.insertDimensionData(dimension, *values)
+    return butler
+
+
+def make_dataset_type(butler, name, dimensions, storageClass):
+    """Create a dataset type in a particular repository.
+
+    Parameters
+    ----------
+    butler : `lsst.daf.butler.Butler`
+        The repository to update.
+    name : `str`
+        The name of the dataset type.
+    dimensions : `set` [`str`]
+        The dimensions of the new dataset type.
+    storageClass : `str`
+        The storage class the dataset will use.
+
+    Returns
+    -------
+    dataset_type : `lsst.daf.butler.DatasetType`
+        The new type.
+
+    Raises
+    ------
+    ValueError
+        Raised if the dimensions or storage class are invalid.
+    ConflictingDefinitionError
+        Raised if another dataset type with the same name already exists.
+    """
+    dataset_type = DatasetType(name, dimensions, storageClass,
+                               universe=butler.registry.dimensions)
+    butler.registry.registerDatasetType(dataset_type)
+    return dataset_type

--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -21,6 +21,7 @@
 
 import unittest
 import astropy.units as u
+import yaml
 
 from lsst.verify.blob import Blob
 from lsst.verify.datum import Datum
@@ -81,6 +82,11 @@ class BlobTestCase(unittest.TestCase):
         # Rebuild from blob
         b2 = Blob.deserialize(**j)
         self.assertEqual(self.blob, b2)
+
+    def test_yaml(self):
+        yaml_form = yaml.dump(self.blob)
+        blob2 = yaml.safe_load(yaml_form)
+        self.assertEqual(self.blob, blob2)
 
     def test_mutation(self):
         blob = Blob('mutable')

--- a/tests/test_blobset.py
+++ b/tests/test_blobset.py
@@ -88,6 +88,8 @@ class BlobSetTestCase(unittest.TestCase):
         self.assertEqual(len(blobs), 2)
         for blob in blobs:
             self.assertIsInstance(blob, Blob)
+        blobs_direct = list(blob_set.values())
+        self.assertEqual(blobs, blobs_direct)
 
         # serialize
         json_doc = blob_set.json

--- a/tests/test_datum.py
+++ b/tests/test_datum.py
@@ -21,6 +21,7 @@
 import unittest
 
 import astropy.units as u
+import yaml
 
 from lsst.verify import Datum
 
@@ -84,15 +85,24 @@ class DatumTestCase(unittest.TestCase):
         self.assertEqual(d.quantity.value, 100.)
         self.assertEqual(d.unit_str, 'mmag')
 
+    def _assertDatumsEqual(self, datum1, datum2):
+        """Test that two Datums are equal without calling ``__eq__``.
+        """
+        self.assertEqual(datum1.quantity, datum2.quantity)
+        self.assertEqual(datum1.unit, datum2.unit)
+        self.assertEqual(datum1.label, datum2.label)
+        self.assertEqual(datum1.description, datum2.description)
+
     def _checkRoundTrip(self, d):
         """Test that a Datum can be serialized and restored.
         """
         json_data = d.json
         d2 = Datum.deserialize(**json_data)
-        self.assertEqual(d.quantity, d2.quantity)
-        self.assertEqual(d.unit, d2.unit)
-        self.assertEqual(d.label, d2.label)
-        self.assertEqual(d.description, d2.description)
+        self._assertDatumsEqual(d, d2)
+
+        yaml_data = yaml.dump(d)
+        d3 = yaml.safe_load(yaml_data)
+        self._assertDatumsEqual(d, d3)
 
     def test_unitless(self):
         """Ensure that Datums can be unitless too."""

--- a/tests/test_datum.py
+++ b/tests/test_datum.py
@@ -84,18 +84,23 @@ class DatumTestCase(unittest.TestCase):
         self.assertEqual(d.quantity.value, 100.)
         self.assertEqual(d.unit_str, 'mmag')
 
-    def test_unitless(self):
-        """Ensure that Datums can be unitless too."""
-        d = Datum(5., '')
-        self.assertEqual(d.unit_str, '')
-        self.assertEqual(d.unit, u.dimensionless_unscaled)
-
+    def _checkRoundTrip(self, d):
+        """Test that a Datum can be serialized and restored.
+        """
         json_data = d.json
         d2 = Datum.deserialize(**json_data)
         self.assertEqual(d.quantity, d2.quantity)
         self.assertEqual(d.unit, d2.unit)
         self.assertEqual(d.label, d2.label)
         self.assertEqual(d.description, d2.description)
+
+    def test_unitless(self):
+        """Ensure that Datums can be unitless too."""
+        d = Datum(5., '')
+        self.assertEqual(d.unit_str, '')
+        self.assertEqual(d.unit, u.dimensionless_unscaled)
+
+        self._checkRoundTrip(d)
 
     def test_str_quantity(self):
         """Quantity as a string."""
@@ -107,12 +112,7 @@ class DatumTestCase(unittest.TestCase):
         self.assertEqual(d.label, 'Test string')
         self.assertEqual(d.description, 'Test description.')
 
-        json_data = d.json
-        d2 = Datum.deserialize(**json_data)
-        self.assertEqual(d.quantity, d2.quantity)
-        self.assertEqual(d.unit, d2.unit)
-        self.assertEqual(d.label, d2.label)
-        self.assertEqual(d.description, d2.description)
+        self._checkRoundTrip(d)
 
     def test_bool_quantity(self):
         """Quantity as a boolean."""
@@ -124,12 +124,7 @@ class DatumTestCase(unittest.TestCase):
         self.assertEqual(d.label, 'Test boolean')
         self.assertEqual(d.description, 'Test description.')
 
-        json_data = d.json
-        d2 = Datum.deserialize(**json_data)
-        self.assertEqual(d.quantity, d2.quantity)
-        self.assertEqual(d.unit, d2.unit)
-        self.assertEqual(d.label, d2.label)
-        self.assertEqual(d.description, d2.description)
+        self._checkRoundTrip(d)
 
     def test_int_quantity(self):
         """Quantity as a unitless int."""
@@ -141,12 +136,7 @@ class DatumTestCase(unittest.TestCase):
         self.assertEqual(d.label, 'Test int')
         self.assertEqual(d.description, 'Test description.')
 
-        json_data = d.json
-        d2 = Datum.deserialize(**json_data)
-        self.assertEqual(d.quantity, d2.quantity)
-        self.assertEqual(d.unit, d2.unit)
-        self.assertEqual(d.label, d2.label)
-        self.assertEqual(d.description, d2.description)
+        self._checkRoundTrip(d)
 
     def test_none(self):
         """Quantity as None."""
@@ -158,12 +148,7 @@ class DatumTestCase(unittest.TestCase):
         self.assertEqual(d.label, 'Test None')
         self.assertEqual(d.description, 'Test description.')
 
-        json_data = d.json
-        d2 = Datum.deserialize(**json_data)
-        self.assertEqual(d.quantity, d2.quantity)
-        self.assertEqual(d.unit, d2.unit)
-        self.assertEqual(d.label, d2.label)
-        self.assertEqual(d.description, d2.description)
+        self._checkRoundTrip(d)
 
     def test_json_output(self):
         """Verify content from json property and deserialization."""

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -22,6 +22,7 @@
 #
 
 import unittest
+import yaml
 
 import astropy.units as u
 from astropy.tests.helper import quantity_allclose
@@ -217,6 +218,23 @@ class MeasurementTestCase(TestCase):
         value = 1235 * u.mag
         m = Measurement(metric, value)
         self.assertEqual(str(m), "test.cmodel_mag: 1235.0 mag")
+
+    def _check_yaml_round_trip(self, old_measurement):
+        persisted = yaml.dump(old_measurement)
+        new_measurement = yaml.safe_load(persisted)
+
+        self.assertEqual(old_measurement, new_measurement)
+        # These fields don't participate in Measurement equality
+        self.assertEqual(old_measurement.identifier,
+                         new_measurement.identifier)
+
+    def test_yamlpersist_basic(self):
+        measurement = Measurement('validate_drp.PA1', 0.002 * u.mag)
+        self._check_yaml_round_trip(measurement)
+
+    def test_yamlpersist_complex(self):
+        measurement = Measurement(self.pa1, 5. * u.mmag)
+        self._check_yaml_round_trip(measurement)
 
 
 if __name__ == "__main__":

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -121,6 +121,7 @@ class MeasurementTestCase(TestCase):
         # Job object.
         new_measurement.notes.update(measurement.notes)
         self.assertEqual(measurement, new_measurement)
+        self.assertEqual(measurement.identifier, new_measurement.identifier)
         self.assertIn('Blob1', measurement.blobs)
         self.assertIn('Blob2', measurement.blobs)
 
@@ -139,6 +140,7 @@ class MeasurementTestCase(TestCase):
 
         new_measurement = Measurement.deserialize(**json_doc)
         self.assertEqual(measurement, new_measurement)
+        self.assertEqual(measurement.identifier, new_measurement.identifier)
 
     def test_PA1_deferred_metric(self):
         """Test a measurement when the Metric instance is added later."""
@@ -187,6 +189,7 @@ class MeasurementTestCase(TestCase):
         new_measurement = Measurement.deserialize(blobs=blobs, **json_doc)
         self.assertIn('extra1', new_measurement.extras)
         self.assertEqual(measurement, new_measurement)
+        self.assertEqual(measurement.identifier, new_measurement.identifier)
 
     def test_deferred_extras(self):
         """Test adding extras to an existing measurement."""

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -227,14 +227,23 @@ class MeasurementTestCase(TestCase):
         # These fields don't participate in Measurement equality
         self.assertEqual(old_measurement.identifier,
                          new_measurement.identifier)
+        self.assertEqual(old_measurement.blobs,
+                         new_measurement.blobs)
+        self.assertEqual(old_measurement.extras,
+                         new_measurement.extras)
 
     def test_yamlpersist_basic(self):
         measurement = Measurement('validate_drp.PA1', 0.002 * u.mag)
         self._check_yaml_round_trip(measurement)
 
     def test_yamlpersist_complex(self):
-        measurement = Measurement(self.pa1, 5. * u.mmag,
-                                  notes={'filter_name': 'r'})
+        measurement = Measurement(
+            self.pa1,
+            5. * u.mmag,
+            notes={'filter_name': 'r'},
+            blobs=[self.blob1],
+            extras={'extra1': Datum(10. * u.arcmin, 'Extra 1')}
+        )
         self._check_yaml_round_trip(measurement)
 
 

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -233,7 +233,8 @@ class MeasurementTestCase(TestCase):
         self._check_yaml_round_trip(measurement)
 
     def test_yamlpersist_complex(self):
-        measurement = Measurement(self.pa1, 5. * u.mmag)
+        measurement = Measurement(self.pa1, 5. * u.mmag,
+                                  notes={'filter_name': 'r'})
         self._check_yaml_round_trip(measurement)
 
 

--- a/ups/verify.table
+++ b/ups/verify.table
@@ -6,6 +6,7 @@ setupRequired(sconsUtils)
 setupRequired(utils)
 setupRequired(log)
 setupRequired(pex_config)
+setupRequired(daf_butler)
 setupRequired(pipe_base)
 setupRequired(dax_apdb)
 


### PR DESCRIPTION
This PR adds Gen 3 Butler support for `lsst.verify.Measurement`. It must be merged after lsst/daf_butler#209.

While `verify` already has JSON persistence code for most of its types, the persisted form for many types, including `Measurement`, is not self-contained and not suitable for standalone datasets. I adopted YAML as the Gen 3 format because I believed it would be no more work than creating a second, more encapsulated, JSON persistence format. In hindsight this was not the case, as I also had to write YAML code for `Datum` and `Blob`, which already have self-contained JSON representations.

The final commit in this PR adds some code for creating simple Butler repositories to `test_measurements.py`. This code will likely be moved to a more central location in the future, but I would like to do some more real-world testing before deciding that's desirable enough to open a Jira issue.