### PR TITLE
DM-22788: Use conda requests package

### DIFF
--- a/ups/verify.table
+++ b/ups/verify.table
@@ -1,6 +1,5 @@
 setupRequired(astropy)
 setupRequired(pyyaml)
-setupRequired(requests)
 setupRequired(numpy)
 setupRequired(sconsUtils)
 setupRequired(utils)


### PR DESCRIPTION
Drops EUPS requests. This old requests library breaks tests when modern `responses` is installed.