### PR TITLE
DM-24438: Support a `refs` environment variable in Jenkins.

### DIFF
--- a/python/lsst/verify/bin/dispatchverify.py
+++ b/python/lsst/verify/bin/dispatchverify.py
@@ -48,6 +48,7 @@ following environment variables are consumed:
 - ``PRODUCT``: the name of the product built, e.g. 'validate_drp'
 - ``dataset``: the name of the dataset processed, e.g. 'validation_data_cfht'
 - ``label``: the name of the platform where it runs
+- ``refs``: the branches run by Jenkins, e.g. 'tickets/DM-12345 master'
 
 If ``--lsstsw`` is used, additional Git branch information is included with
 Science Pipelines package metadata.

--- a/python/lsst/verify/metadata/jenkinsci.py
+++ b/python/lsst/verify/metadata/jenkinsci.py
@@ -40,6 +40,7 @@ def get_jenkins_env():
         - ``'ci_label'``: Value of ``${label}`` environment variable in
           Jenkins CI.
         - ``'ci_url'``: URL to job page in Jenkins CI.
+        - ``'ci_refs'``: whitespace-delimited branch references
         - ``'status'``: Job return status (always ``0``).
 
     Examples
@@ -57,6 +58,7 @@ def get_jenkins_env():
         'ci_name': os.getenv('PRODUCT', 'unknown'),
         'ci_dataset': os.getenv('dataset', 'unknown'),
         'ci_label': os.getenv('label', 'unknown'),
+        'ci_refs': os.getenv('refs', 'unknown'),
         'ci_url': os.getenv('BUILD_URL', 'https://example.com'),
         'status': 0,
     }


### PR DESCRIPTION
This environment variable specifies a list of branch names, in the
format used by the Jenkins jobs stack_os_matrix.