### PR TITLE
Make serialized job more readable

### DIFF
--- a/python/lsst/verify/job.py
+++ b/python/lsst/verify/job.py
@@ -302,7 +302,7 @@ class Job(JsonSerializationMixin):
                 os.makedirs(dirname)
 
         with open(filename, 'w') as f:
-            json.dump(self.json, f)
+            json.dump(self.json, f, indent=2, sort_keys=True)
 
     def dispatch(self, api_user=None, api_password=None,
                  api_url='https://squash-restful-api.lsst.codes',


### PR DESCRIPTION
DM-24741: Make serialized `Job` data more readable

This is a simple, non-API, change that will make the JSON output from `Job.write()` more readable.
This is purely for devs to look at output to spot check for validity.
****

- [x] Passes Jenkins CI.
- [x] Documentation is up-to-date.

Preview the docs at: Docs are unchanged.