### PR TITLE
DM-21919: Run ap_verify end-to-end in Gen 3

### DIFF
--- a/python/lsst/verify/tasks/commonMetrics.py
+++ b/python/lsst/verify/tasks/commonMetrics.py
@@ -54,6 +54,7 @@ class TimeMethodMetricConfig(MetadataMetricConfig):
             "in the format of `lsst.pipe.base.Task.getFullMetadata()`.")
     metric = pexConfig.Field(
         dtype=str,
+        optional=True,
         doc="The fully qualified name of the metric to store the "
             "profiling information.",
         deprecated="This field has been replaced by connections.package and "

--- a/python/lsst/verify/tasks/metadataMetricTask.py
+++ b/python/lsst/verify/tasks/metadataMetricTask.py
@@ -31,7 +31,7 @@ from lsst.verify.tasks import MetricTask, MetricConfig, MetricConnections, \
 
 class SingleMetadataMetricConnections(
         MetricConnections,
-        dimensions={"instrument", "exposure", "detector"},
+        dimensions={"instrument", "visit", "detector"},
         defaultTemplates={"labelName": "", "package": None, "metric": None}):
     """An abstract connections class defining a metadata input.
 
@@ -56,7 +56,7 @@ class SingleMetadataMetricConnections(
         doc="The target top-level task's metadata. The name must be set to "
             "the metadata's butler type, such as 'processCcd_metadata'.",
         storageClass="PropertySet",
-        dimensions={"Instrument", "Exposure", "Detector"},
+        dimensions={"instrument", "visit", "detector"},
         multiple=False,
     )
 

--- a/python/lsst/verify/tasks/testUtils.py
+++ b/python/lsst/verify/tasks/testUtils.py
@@ -158,6 +158,19 @@ class MetadataMetricTestCase(gen2Utils.MetricTaskTestCase, MetricTaskTestCase):
                 else:
                     self.task.run([None])
 
+    def testDimensionsOverride(self):
+        config = self.task.config
+        expectedDimensions = {"instrument", "visit"}
+        config.metadataDimensions = expectedDimensions
+
+        connections = config.connections.ConnectionsClass(config=config)
+        self.assertSetEqual(set(connections.dimensions),
+                            expectedDimensions)
+        self.assertIn(connections.metadata,
+                      connections.allConnections.values())
+        self.assertSetEqual(set(connections.metadata.dimensions),
+                            expectedDimensions)
+
 
 class ApdbMetricTestCase(gen2Utils.MetricTaskTestCase, MetricTaskTestCase):
     """Unit test base class for tests of `ApdbMetricTask`.


### PR DESCRIPTION
This PR fixes several bugs in `MetadataMetricTask` that were discovered while developing `ap_verify`, and makes the task's dimensions configurable to support metadata from a variety of science pipeline tasks.