### PR TITLE
DM-26671: Ignore import errors for bin.src/bin differences

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,5 +9,5 @@ exclude =
   tests/.tests/
 
 [tool:pytest]
-addopts = --flake8 --doctest-plus
+addopts = --flake8 --doctest-plus --doctest-ignore-import-errors
 flake8-ignore = E133 E226 E228 N802 N803 N806 N812 N815 N816 W504


### PR DESCRIPTION
pytest-doctestplus started throwing errors when import paths don't match correctly. There are some errors with how bin.src is handled in the unit tests in this scenario. This is the only package that experienced such errors. Adding an extra flag, `--doctest-ignore-import-errors`, keeps the old behavior of pytest-doctestplus

This flag works with pytest-doctestplus 0.6.1 and future versions which are not yet in the stack.

****

- [X] Passes Jenkins CI.
- [ ] Documentation is up-to-date.
