### PR TITLE
DM-27325: Can't rerun ap_verify on same repository in Gen 3

### DIFF
--- a/python/lsst/verify/tasks/metadataMetricTask.py
+++ b/python/lsst/verify/tasks/metadataMetricTask.py
@@ -93,7 +93,8 @@ class MetadataMetricConfig(
     """A base class for metadata metric task configs.
     """
     metadataDimensions = lsst.pex.config.ListField(
-        default=SingleMetadataMetricConnections.dimensions,
+        # Sort to ensure default order is consistent between runs
+        default=sorted(SingleMetadataMetricConnections.dimensions),
         dtype=str,
         doc="Override for the dimensions of the 'metadata' input, when "
             "instrumenting Tasks that don't produce one metadata object "


### PR DESCRIPTION
This PR fixes a bug in `MetadataMetricTask` that made it difficult to run the task repeatedly on the same run collection.