### PR TITLE
DM-29509: Add the version when MetricTask was deprecated

### DIFF
--- a/python/lsst/verify/gen2tasks/metricTask.py
+++ b/python/lsst/verify/gen2tasks/metricTask.py
@@ -34,6 +34,7 @@ from ..tasks.metricTask import MetricTask as Gen3MetricTask
 @deprecated(
     reason="Replaced by `lsst.verify.tasks.MetricTask`. "
            "To be removed along with daf_persistence.",
+    version="v20.0",
     category=FutureWarning)
 class MetricTask(Gen3MetricTask, metaclass=abc.ABCMeta):
     """A base class for tasks that compute one metric from input datasets.


### PR DESCRIPTION
This version is now mandatory.

{Summary of changes. Prefix PR title with ticket handle.}

****

- [ ] Passes Jenkins CI.
- [ ] Documentation is up-to-date.

Preview the docs at: https://pipelines.lsst.io/v/DM-FIXME
