### PR TITLE
[DM-30940] Add the --date-created command line option to dispatch_verify.py

### DIFF
--- a/python/lsst/verify/metadata/jenkinsci.py
+++ b/python/lsst/verify/metadata/jenkinsci.py
@@ -20,7 +20,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 __all__ = ['get_jenkins_env']
 
-from datetime import datetime, timezone
 import os
 
 
@@ -33,7 +32,6 @@ def get_jenkins_env():
         Dictionary of metadata items obtained from the Jenkins CI
         environment. Fields are:
 
-        - ``'date'``: ISO8601-formatted current datetime.
         - ``'ci_id'``: Job ID in Jenkins CI.
         - ``'ci_name'``: Job name in Jenkins CI.
         - ``'ci_dataset'``: Name of the dataset being processed.
@@ -53,7 +51,6 @@ def get_jenkins_env():
     """
 
     return {
-        'date': datetime.now(timezone.utc).isoformat(),
         'ci_id': os.getenv('BUILD_ID', 'unknown'),
         'ci_name': os.getenv('PRODUCT', 'unknown'),
         'ci_dataset': os.getenv('dataset', 'unknown'),

--- a/python/lsst/verify/metadata/ldf.py
+++ b/python/lsst/verify/metadata/ldf.py
@@ -20,7 +20,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 __all__ = ['get_ldf_env']
 
-from datetime import datetime, timezone
 import os
 
 
@@ -33,7 +32,6 @@ def get_ldf_env():
         Dictionary of metadata items obtained from the LDF environment.
         Fields are:
 
-        - ``'date'``: ISO8601-formatted current datetime.
         - ``'dataset'``: the name of the dataset processed.
         - ``'dataset_repo_url'``: a reference URL with information about the
         dataset.
@@ -51,7 +49,6 @@ def get_ldf_env():
     """
 
     return {
-        'date': datetime.now(timezone.utc).isoformat(),
         'dataset': os.getenv('DATASET', 'unknown'),
         'dataset_repo_url': os.getenv('DATASET_REPO_URL',
                                       'https://example.com'),


### PR DESCRIPTION
- Job creation date to add in the Job metadata, if not specified the default behaviour is to use the current datetime.
- Expects a ISO8601 formatted datetime in UTC


****

- [x] Passes Jenkins CI.
- [x] Documentation is up-to-date.

Preview the docs at: https://pipelines.lsst.io/v/DM-30940
