### PR TITLE
Remove deprecated use of lsst.log.

### DIFF
--- a/python/lsst/verify/gen2tasks/metricsControllerTask.py
+++ b/python/lsst/verify/gen2tasks/metricsControllerTask.py
@@ -22,7 +22,6 @@
 __all__ = ["MetricsControllerConfig", "MetricsControllerTask"]
 
 import os.path
-import traceback
 
 import lsst.pex.config as pexConfig
 import lsst.daf.persistence as dafPersist
@@ -177,10 +176,9 @@ class MetricsControllerTask(Task):
                     "Skipping measurement of %r on %s as not applicable.",
                     metricTask, inputDataIds)
         except MetricComputationError:
-            # Apparently lsst.log doesn't have built-in exception support?
-            self.log.error("Measurement of %r failed on %s->%s\n%s",
+            self.log.error("Measurement of %r failed on %s->%s",
                            metricTask, inputDataIds, outputDataIds,
-                           traceback.format_exc())
+                           exc_info=True)
 
     def runDataRefs(self, datarefs, customMetadata=None, skipExisting=False):
         """Call all registered metric tasks on each dataref.

--- a/python/lsst/verify/tasks/apdbMetricTask.py
+++ b/python/lsst/verify/tasks/apdbMetricTask.py
@@ -23,7 +23,6 @@ __all__ = ["ApdbMetricTask", "ApdbMetricConfig", "ConfigApdbLoader",
            "DirectApdbLoader", "ApdbMetricConnections"]
 
 import abc
-import traceback
 
 from lsst.pex.config import Config, ConfigurableField, ConfigurableInstance, \
     ConfigDictField, ConfigChoiceField, FieldValidationError
@@ -352,10 +351,9 @@ class ApdbMetricTask(MetricTask):
             if outputs.measurement is not None:
                 butlerQC.put(outputs, outputRefs)
             else:
-                self.log.debugf("Skipping measurement of {!r} on {} "
-                                "as not applicable.", self, inputRefs)
+                self.log.debug("Skipping measurement of %r on %s "
+                               "as not applicable.", self, inputRefs)
         except MetricComputationError:
-            # Apparently lsst.log doesn't have built-in exception support?
-            self.log.errorf(
-                "Measurement of {!r} failed on {}->{}\n{}",
-                self, inputRefs, outputRefs, traceback.format_exc())
+            self.log.error(
+                "Measurement of %r failed on %s->%s",
+                self, inputRefs, outputRefs, exc_info=True)

--- a/python/lsst/verify/tasks/metricTask.py
+++ b/python/lsst/verify/tasks/metricTask.py
@@ -25,7 +25,6 @@ __all__ = ["MetricComputationError", "MetricTask", "MetricConfig",
 
 
 import abc
-import traceback
 
 import lsst.pipe.base as pipeBase
 from lsst.pipe.base import connectionTypes
@@ -180,13 +179,12 @@ class MetricTask(pipeBase.PipelineTask, metaclass=abc.ABCMeta):
             if outputs.measurement is not None:
                 butlerQC.put(outputs, outputRefs)
             else:
-                self.log.debugf("Skipping measurement of {!r} on {} "
-                                "as not applicable.", self, inputRefs)
+                self.log.debug("Skipping measurement of %r on %s "
+                               "as not applicable.", self, inputRefs)
         except MetricComputationError:
-            # Apparently lsst.log doesn't have built-in exception support?
-            self.log.errorf(
-                "Measurement of {!r} failed on {}->{}\n{}",
-                self, inputRefs, outputRefs, traceback.format_exc())
+            self.log.error(
+                "Measurement of %r failed on %s->%s",
+                self, inputRefs, outputRefs, exc_info=True)
 
     def adaptArgsAndRun(self, inputData, inputDataIds, outputDataId):
         """A wrapper around `run` used by


### PR DESCRIPTION
This PR fixes some deprecation warnings related to the task logger transition. It does not attempt to remove local construction of `lsst.log.Log` objects.