### PR TITLE
DM-31609: lsst.verify.Measurement needs a useful __repr__()

### DIFF
--- a/python/lsst/verify/measurement.py
+++ b/python/lsst/verify/measurement.py
@@ -216,6 +216,29 @@ class Measurement(JsonSerializationMixin):
     def __str__(self):
         return f"{self.metric_name!s}: {self.quantity!s}"
 
+    def __repr__(self):
+        metricString = str(self.metric_name)
+        # For readability, don't print rarely-used components if they're None
+        args = [repr(str(metricString)),
+                repr(self.quantity),
+                ]
+
+        # invariant: self.blobs always exists and contains at least extras
+        if self.blobs.keys() - {metricString}:
+            pureBlobs = self.blobs.copy()
+            del pureBlobs[metricString]
+            args.append(f"blobs={list(pureBlobs.values())!r}")
+
+        # invariant: self.extras always exists, but may be empty
+        if self.extras:
+            args.append(f"extras={dict(self.extras)!r}")
+
+        # invariant: self.notes always exists, but may be empty
+        if self.notes:
+            args.append(f"notes={dict(self.notes)!r}")
+
+        return f"Measurement({', '.join(args)})"
+
     def _repr_latex_(self):
         """Get a LaTeX-formatted string representation of the measurement
         quantity (used in Jupyter notebooks).

--- a/python/lsst/verify/measurement.py
+++ b/python/lsst/verify/measurement.py
@@ -214,7 +214,7 @@ class Measurement(JsonSerializationMixin):
         return self._id
 
     def __str__(self):
-        return "{self.metric_name!s}: {self.quantity!s}".format(self=self)
+        return f"{self.metric_name!s}: {self.quantity!s}"
 
     def _repr_latex_(self):
         """Get a LaTeX-formatted string representation of the measurement

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -219,6 +219,31 @@ class MeasurementTestCase(TestCase):
         m = Measurement(metric, value)
         self.assertEqual(str(m), "test.cmodel_mag: 1235.0 mag")
 
+    def test_repr(self):
+        metric = 'test.cmodel_mag'
+        self.assertEqual(
+            repr(Measurement(metric)),
+            "Measurement('test.cmodel_mag', None)")
+        value = 1235 * u.mag
+        self.assertEqual(
+            repr(Measurement(metric, value)),
+            "Measurement('test.cmodel_mag', <Quantity 1235. mag>)")
+
+        self.assertEqual(
+            repr(Measurement(metric, value, [self.blob1])),
+            "Measurement('test.cmodel_mag', <Quantity 1235. mag>, "
+            f"blobs=[{self.blob1!r}])"
+        )
+
+        notes = {metric + '.filter_name': 'r'}
+        extras = {'extra1': Datum(10. * u.arcmin, 'Extra 1')}
+        self.assertEqual(
+            repr(Measurement(metric, value, notes=notes, blobs=[self.blob1],
+                             extras=extras)),
+            "Measurement('test.cmodel_mag', <Quantity 1235. mag>, "
+            f"blobs=[{self.blob1!r}], extras={extras!r}, notes={notes!r})"
+        )
+
     def _check_yaml_round_trip(self, old_measurement):
         persisted = yaml.dump(old_measurement)
         new_measurement = yaml.safe_load(persisted)


### PR DESCRIPTION
This PR adds a constructor-like implementation of `Measurement.__repr__`. Since the internal state of `Measurement` is not trivially related to its constructor arguments, this requires some on-the-fly conversion.