### PR TITLE
[DM-31131] lsst.verify outputs non-standard NaN in JSON

### DIFF
--- a/python/lsst/verify/measurement.py
+++ b/python/lsst/verify/measurement.py
@@ -22,6 +22,7 @@ __all__ = ['Measurement', 'MeasurementNotes']
 
 import uuid
 
+import numpy as np
 import astropy.units as u
 from astropy.tests.helper import quantity_allclose
 
@@ -335,6 +336,10 @@ class Measurement(JsonSerializationMixin):
             _normalized_value = self.quantity.value
             _normalized_unit_str = str(self.quantity.unit)
 
+        # Represent NaN, positive infinity, or negative infinity as None
+        if _normalized_value and not np.isfinite(_normalized_value):
+            _normalized_value = None
+
         blob_refs = [b.identifier for k, b in self.blobs.items()]
         # Remove any reference to an empty extras blob
         if len(self.extras) == 0:
@@ -387,7 +392,9 @@ class Measurement(JsonSerializationMixin):
         else:
             _blobs = None
 
-        # Resolve quantity
+        # Resolve quantity, represent None values as np.nan
+        if value is None:
+            value = np.nan
         _quantity = u.Quantity(value, u.Unit(unit))
 
         instance = cls(metric, quantity=_quantity, blobs=_blobs)

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -23,6 +23,7 @@
 
 import unittest
 import yaml
+import numpy as np
 
 import astropy.units as u
 from astropy.tests.helper import quantity_allclose
@@ -142,6 +143,28 @@ class MeasurementTestCase(TestCase):
         new_measurement = Measurement.deserialize(**json_doc)
         self.assertEqual(measurement, new_measurement)
         self.assertEqual(measurement.identifier, new_measurement.identifier)
+
+    def test_PA1_measurement_with_nan(self):
+        """Test (de)serialization of a measurement with value np.nan."""
+        measurement = Measurement('PA1', np.nan * u.mag)
+
+        json_doc = measurement.json
+        # a np.nan value is serialized to None
+        self.assertEqual(json_doc['value'], None)
+        # a None value is deserialized to np.nan
+        new_measurement = Measurement.deserialize(**json_doc)
+        self.assertEqual(str(new_measurement), 'PA1: nan mag')
+
+    def test_PA1_measurement_with_inf(self):
+        """Test (de)serialization of a measurement with value np.inf."""
+        measurement = Measurement('PA1', np.inf * u.mag)
+
+        json_doc = measurement.json
+        # a np.inf value is also serialized to None
+        self.assertEqual(json_doc['value'], None)
+        # but once it is None, we can only deserialized it to np.nan
+        new_measurement = Measurement.deserialize(**json_doc)
+        self.assertEqual(str(new_measurement), 'PA1: nan mag')
 
     def test_PA1_deferred_metric(self):
         """Test a measurement when the Metric instance is added later."""


### PR DESCRIPTION
Represent metric values that are ``np.nan`` (or ``np.inf``) in ``verify`` as ``null`` when serializing a job to a JSON document.  When deserializing a JSON document a metric values that is ``null``  is explicitly converted to ``np.nan``.

- [x] Passes Jenkins CI.
- [X] Documentation is up-to-date.

