### PR TITLE
DM-31458: Update verify for changes in APDB API 

### DIFF
--- a/python/lsst/verify/tasks/apdbMetricTask.py
+++ b/python/lsst/verify/tasks/apdbMetricTask.py
@@ -27,7 +27,7 @@ import abc
 from lsst.pex.config import Config, ConfigurableField, ConfigurableInstance, \
     ConfigDictField, ConfigChoiceField, FieldValidationError
 from lsst.pipe.base import Task, Struct, connectionTypes
-from lsst.dax.apdb import Apdb, ApdbConfig
+from lsst.dax.apdb import make_apdb, ApdbConfig
 
 from lsst.verify.tasks import MetricTask, MetricConfig, MetricConnections, \
     MetricComputationError
@@ -67,7 +67,7 @@ class ConfigApdbLoader(Task):
         if config is None:
             return None
         if isinstance(config, ApdbConfig):
-            return Apdb(config)
+            return make_apdb(config)
 
         for field in config.values():
             if isinstance(field, ConfigurableInstance):
@@ -112,7 +112,7 @@ class ConfigApdbLoader(Task):
         if configurable is None:
             return None
 
-        if configurable.ConfigClass == ApdbConfig:
+        if issubclass(configurable.ConfigClass, ApdbConfig):
             return configurable.apply()
         else:
             return self._getApdb(configurable.value)
@@ -192,7 +192,7 @@ class DirectApdbLoader(Task):
             ``apdb``
                 A database configured the same way as in ``config``.
         """
-        return Struct(apdb=(Apdb(config) if config else None))
+        return Struct(apdb=(make_apdb(config) if config else None))
 
 
 class ApdbMetricConnections(

--- a/tests/test_directApdbLoader.py
+++ b/tests/test_directApdbLoader.py
@@ -22,7 +22,7 @@
 import unittest
 
 import lsst.utils.tests
-from lsst.dax.apdb import Apdb, ApdbConfig
+from lsst.dax.apdb import Apdb, ApdbSqlConfig
 
 from lsst.verify.tasks import DirectApdbLoader
 
@@ -31,9 +31,8 @@ class DirectApdbLoaderTestSuite(lsst.utils.tests.TestCase):
 
     @staticmethod
     def _dummyApdbConfig():
-        config = ApdbConfig()
+        config = ApdbSqlConfig()
         config.db_url = "sqlite://"     # in-memory DB
-        config.isolation_level = "READ_UNCOMMITTED"
         return config
 
     def setUp(self):


### PR DESCRIPTION
Use factory method to make Apdb instance instead of calling Apdb
constructor. Unit tests use SQL-base implementation of Apdb and need
to use correct config class.

****

- [X] Passes Jenkins CI.
- [ ] Documentation is up-to-date.

Preview the docs at: https://pipelines.lsst.io/v/DM-FIXME
