### PR TITLE
DM-31801: Use python logging with __name__

### DIFF
--- a/python/lsst/verify/bin/dispatchverify.py
+++ b/python/lsst/verify/bin/dispatchverify.py
@@ -77,6 +77,7 @@ import json
 import getpass
 from dateutil import parser as date_parser
 from datetime import datetime, timezone
+import logging
 
 try:
     import git
@@ -84,12 +85,13 @@ except ImportError:
     # GitPython is not a standard Stack package; skip gracefully if unavailable
     git = None
 
-import lsst.log
 from lsst.verify import Job
 from lsst.verify.metadata.lsstsw import LsstswRepos
 from lsst.verify.metadata.eupsmanifest import Manifest
 from lsst.verify.metadata.jenkinsci import get_jenkins_env
 from lsst.verify.metadata.ldf import get_ldf_env
+
+_LOG = logging.getLogger(__name__)
 
 
 def build_argparser():
@@ -201,7 +203,7 @@ def build_argparser():
 def main():
     """Entrypoint for the ``dispatch_verify.py`` command line executable.
     """
-    log = lsst.log.Log.getLogger('verify.bin.dispatchverify.main')
+    log = _LOG.getChild('main')
 
     parser = build_argparser()
     args = parser.parse_args()
@@ -312,8 +314,7 @@ def insert_extra_package_metadata(job, config):
     """Insert metadata for extra packages ('--package-repos') into
     ``Job.meta['packages']``.
     """
-    log = lsst.log.Log.getLogger(
-        'verify.bin.dispatchverify.insert_extra_package_metadata')
+    log = _LOG.getChild("insert_extra_package_metadata")
 
     if 'packages' not in job.meta:
         job.meta['packages'] = dict()

--- a/python/lsst/verify/squash.py
+++ b/python/lsst/verify/squash.py
@@ -33,8 +33,7 @@ __all__ = ['get', 'post', 'get_endpoint_url', 'reset_endpoint_cache',
 
 
 import requests
-
-import lsst.log
+import logging
 
 # Version of the SQUASH API this client is compatible with
 _API_VERSION = '1.0'
@@ -44,6 +43,8 @@ _TIMEOUT = 900.0
 
 # URLs for SQUASH endpoints, cached by `get_endpoint_url()`.
 _ENDPOINT_URLS = None
+
+_LOG = logging.getLogger(__name__)
 
 
 def get_endpoint_url(api_url, api_endpoint, **kwargs):
@@ -215,7 +216,7 @@ def post(api_url, api_endpoint, json_doc=None,
     response : `requests.Response`
         Response object. Obtain JSON content with ``response.json()``.
     """
-    log = lsst.log.Log.getLogger('verify.squash.post')
+    log = _LOG.getChild('post')
 
     api_endpoint_url = get_endpoint_url(api_url, api_endpoint)
 
@@ -284,7 +285,7 @@ def get(api_url, api_endpoint=None,
     response : `requests.Response`
         Response object. Obtain JSON content with ``response.json()``.
     """
-    log = lsst.log.Log.getLogger('verify.squash.get')
+    log = _LOG.getChild('get')
 
     if api_user is not None and api_password is not None:
         auth = (api_user, api_password)


### PR DESCRIPTION
Now that `lsst` prefix is allowed we can use `__name__` with `logger.getChild`.

****

- [x] Passes Jenkins CI.
- [x] Documentation is up-to-date.

Preview the docs at: https://pipelines.lsst.io/v/DM-FIXME
