### PR TITLE
DM-32226: Replace `pipe.base.timeMethod` with `utils.timer`

### DIFF
--- a/doc/lsst.verify/tasks/lsst.verify.tasks.MemoryMetricTask.rst
+++ b/doc/lsst.verify/tasks/lsst.verify.tasks.MemoryMetricTask.rst
@@ -4,20 +4,20 @@
 MemoryMetricTask
 ################
 
-``MemoryMetricTask`` creates a resident set size `~lsst.verify.Measurement` based on data collected by @\ `~lsst.pipe.base.timeMethod`.
+``MemoryMetricTask`` creates a resident set size `~lsst.verify.Measurement` based on data collected by @\ `~lsst.utils.timer.timeMethod`.
 It reads the raw timing data from the top-level `~lsst.pipe.base.CmdLineTask`'s metadata, which is identified by the task configuration.
 
 In general, it's only useful to measure this metric for the top-level task being run.
-@\ `~lsst.pipe.base.timeMethod` measures the peak memory usage from process start, so the results for any subtask will be contaminated by previous subtasks run on the same data ID.
+@\ `~lsst.utils.timer.timeMethod` measures the peak memory usage from process start, so the results for any subtask will be contaminated by previous subtasks run on the same data ID.
 
-Because @\ `~lsst.pipe.base.timeMethod` gives platform-dependent results, this task may give incorrect results (e.g., units) when run in a distributed system with heterogeneous nodes.
+Because @\ `~lsst.utils.timer.timeMethod` gives platform-dependent results, this task may give incorrect results (e.g., units) when run in a distributed system with heterogeneous nodes.
 
 .. _lsst.verify.tasks.MemoryMetricTask-summary:
 
 Processing summary
 ==================
 
-``MemoryMetricTask`` searches the metadata for @\ `~lsst.pipe.base.timeMethod`-generated keys corresponding to the method of interest.
+``MemoryMetricTask`` searches the metadata for @\ `~lsst.utils.timer.timeMethod`-generated keys corresponding to the method of interest.
 If it finds matching keys, it stores the maximum memory usage as a `~lsst.verify.Measurement`.
 
 .. _lsst.verify.tasks.MemoryMetricTask-api:

--- a/doc/lsst.verify/tasks/lsst.verify.tasks.TimingMetricTask.rst
+++ b/doc/lsst.verify/tasks/lsst.verify.tasks.TimingMetricTask.rst
@@ -4,7 +4,7 @@
 TimingMetricTask
 ################
 
-``TimingMetricTask`` creates a wall-clock timing `~lsst.verify.Measurement` based on data collected by @\ `~lsst.pipe.base.timeMethod`.
+``TimingMetricTask`` creates a wall-clock timing `~lsst.verify.Measurement` based on data collected by @\ `~lsst.utils.timer.timeMethod`.
 It reads the raw timing data from the top-level `~lsst.pipe.base.CmdLineTask`'s metadata, which is identified by the task configuration.
 
 .. _lsst.verify.tasks.TimingMetricTask-summary:
@@ -12,7 +12,7 @@ It reads the raw timing data from the top-level `~lsst.pipe.base.CmdLineTask`'s 
 Processing summary
 ==================
 
-``TimingMetricTask`` searches the metadata for @\ `~lsst.pipe.base.timeMethod`-generated keys corresponding to the method of interest.
+``TimingMetricTask`` searches the metadata for @\ `~lsst.utils.timer.timeMethod`-generated keys corresponding to the method of interest.
 If it finds matching keys, it stores the elapsed time as a `~lsst.verify.Measurement`.
 
 .. _lsst.verify.tasks.TimingMetricTask-api:

--- a/python/lsst/verify/tasks/commonMetrics.py
+++ b/python/lsst/verify/tasks/commonMetrics.py
@@ -43,10 +43,10 @@ from lsst.verify.tasks import MetricComputationError, MetadataMetricTask, \
 
 
 class TimeMethodMetricConfig(MetadataMetricConfig):
-    """Common config fields for metrics based on `~lsst.pipe.base.timeMethod`.
+    """Common config fields for metrics based on `~lsst.utils.timer.timeMethod`.
 
     These fields let metrics distinguish between different methods that have
-    been decorated with `~lsst.pipe.base.timeMethod`.
+    been decorated with `~lsst.utils.timer.timeMethod`.
     """
     target = pexConfig.Field(
         dtype=str,
@@ -87,7 +87,7 @@ TimingMetricConfig = TimeMethodMetricConfig
 @registerMultiple("timing")
 class TimingMetricTask(MetadataMetricTask):
     """A Task that computes a wall-clock time using metadata produced by the
-    `lsst.pipe.base.timeMethod` decorator.
+    `lsst.utils.timer.timeMethod` decorator.
 
     Parameters
     ----------
@@ -129,7 +129,7 @@ class TimingMetricTask(MetadataMetricTask):
 
     def makeMeasurement(self, timings):
         """Compute a wall-clock measurement from metadata provided by
-        `lsst.pipe.base.timeMethod`.
+        `lsst.utils.timer.timeMethod`.
 
         Parameters
         ----------
@@ -163,7 +163,7 @@ class TimingMetricTask(MetadataMetricTask):
             else:
                 meas = Measurement(self.config.metricName,
                                    totalTime * u.second)
-                meas.notes["estimator"] = "pipe.base.timeMethod"
+                meas.notes["estimator"] = "utils.timer.timeMethod"
                 if timings["StartTimestamp"]:
                     meas.extras["start"] = Datum(timings["StartTimestamp"])
                 if timings["EndTimestamp"]:
@@ -182,7 +182,7 @@ MemoryMetricConfig = TimeMethodMetricConfig
 @registerMultiple("memory")
 class MemoryMetricTask(MetadataMetricTask):
     """A Task that computes the maximum resident set size using metadata
-    produced by the `lsst.pipe.base.timeMethod` decorator.
+    produced by the `lsst.utils.timer.timeMethod` decorator.
 
     Parameters
     ----------
@@ -218,7 +218,7 @@ class MemoryMetricTask(MetadataMetricTask):
 
     def makeMeasurement(self, memory):
         """Compute a maximum resident set size measurement from metadata
-        provided by `lsst.pipe.base.timeMethod`.
+        provided by `lsst.utils.timer.timeMethod`.
 
         Parameters
         ----------
@@ -247,7 +247,7 @@ class MemoryMetricTask(MetadataMetricTask):
             else:
                 meas = Measurement(self.config.metricName,
                                    self._addUnits(maxMemory))
-                meas.notes['estimator'] = 'pipe.base.timeMethod'
+                meas.notes['estimator'] = 'utils.timer.timeMethod'
                 return meas
         else:
             self.log.info("Nothing to do: no memory information for %s found.",

--- a/tests/test_commonMetrics.py
+++ b/tests/test_commonMetrics.py
@@ -27,7 +27,8 @@ import astropy.units as u
 
 import lsst.utils.tests
 from lsst.pex.config import Config
-from lsst.pipe.base import Task, timeMethod
+from lsst.pipe.base import Task
+from lsst.utils.timer import timeMethod
 
 from lsst.verify import Measurement, Name
 from lsst.verify.gen2tasks.testUtils import MetricTaskTestCase


### PR DESCRIPTION

****

- [X] Passes Jenkins CI.
- [ ] Documentation is up-to-date.

Preview the docs at: https://pipelines.lsst.io/v/DM-FIXME
