### PR TITLE
DM-33220: Change Task metadata storage class to TaskMetadata

### DIFF
--- a/python/lsst/verify/tasks/metadataMetricTask.py
+++ b/python/lsst/verify/tasks/metadataMetricTask.py
@@ -159,7 +159,7 @@ class AbstractMetadataMetricTask(MetricTask):
 
         Parameters
         ----------
-        metadata : `lsst.daf.base.PropertySet`
+        metadata : `lsst.pipe.base.TaskMetadata`
             A metadata object with task-qualified keys as returned by
             `lsst.pipe.base.Task.getFullMetadata()`.
         keyFragment : `str`
@@ -179,7 +179,7 @@ class AbstractMetadataMetricTask(MetricTask):
 
         Parameters
         ----------
-        metadata : `lsst.daf.base.PropertySet`
+        metadata : `lsst.pipe.base.TaskMetadata`
             A metadata object, assumed not `None`.
         metadataKeys : `dict` [`str`, `str`]
             Keys are arbitrary labels, values are metadata keys (or their
@@ -270,7 +270,7 @@ class MetadataMetricTask(AbstractMetadataMetricTask):
 
         Parameters
         ----------
-        metadata : `lsst.daf.base.PropertySet` or `None`
+        metadata : `lsst.pipe.base.TaskMetadata` or `None`
             A metadata object for the unit of science processing to use for
             this metric, or a collection of such objects if this task combines
             many units of processing into a single metric.

--- a/python/lsst/verify/tasks/metadataMetricTask.py
+++ b/python/lsst/verify/tasks/metadataMetricTask.py
@@ -58,7 +58,7 @@ class SingleMetadataMetricConnections(
         name="{labelName}_metadata",
         doc="The target top-level task's metadata. The name must be set to "
             "the metadata's butler type, such as 'processCcd_metadata'.",
-        storageClass="PropertySet",
+        storageClass="TaskMetadata",
         dimensions={"instrument", "visit", "detector"},
         multiple=False,
     )

--- a/python/lsst/verify/tasks/testUtils.py
+++ b/python/lsst/verify/tasks/testUtils.py
@@ -27,7 +27,7 @@ import unittest.mock
 from unittest.mock import patch
 
 import lsst.utils.tests
-from lsst.daf.base import PropertySet
+from lsst.pipe.base import TaskMetadata
 from lsst.dax.apdb import ApdbConfig
 
 import lsst.verify.gen2tasks.testUtils as gen2Utils
@@ -119,7 +119,7 @@ class MetadataMetricTestCase(gen2Utils.MetricTaskTestCase, MetricTaskTestCase):
                           return_value={"unused": mockKey}), \
                 patch.object(self.task, "makeMeasurement") as mockWorkhorse:
             if self._takesScalarMetadata(self.task):
-                metadata1 = PropertySet()
+                metadata1 = TaskMetadata()
                 metadata1[mockKey] = 42
 
                 self.task.run(metadata1)
@@ -128,9 +128,9 @@ class MetadataMetricTestCase(gen2Utils.MetricTaskTestCase, MetricTaskTestCase):
                 self.task.run(None)
                 mockWorkhorse.assert_called_once_with({"unused": None})
             else:
-                metadata1 = PropertySet()
+                metadata1 = TaskMetadata()
                 metadata1[mockKey] = 42
-                metadata2 = PropertySet()
+                metadata2 = TaskMetadata()
                 metadata2[mockKey] = "Sphere"
                 self.task.run([metadata1, None, metadata2])
                 mockWorkhorse.assert_called_once_with(
@@ -140,7 +140,7 @@ class MetadataMetricTestCase(gen2Utils.MetricTaskTestCase, MetricTaskTestCase):
         mockKey = "unitTestKey"
         with patch.object(self.task, "getInputMetadataKeys",
                           return_value={"unused": mockKey}):
-            metadata = PropertySet()
+            metadata = TaskMetadata()
             metadata[mockKey + "1"] = 42
             metadata[mockKey + "2"] = "Sphere"
             with self.assertRaises(MetricComputationError):

--- a/tests/test_metricsController.py
+++ b/tests/test_metricsController.py
@@ -52,7 +52,7 @@ class DemoConnections(
         dimensions={}):
     inputData = connectionTypes.Input(
         name="metadata",
-        storageClass="PropertySet",
+        storageClass="TaskMetadata",
     )
 
 


### PR DESCRIPTION
This is now the standard storage class for task metadata.

{Summary of changes. Prefix PR title with ticket handle.}

****

- [x] Passes Jenkins CI.
- [ ] Documentation is up-to-date.

Preview the docs at: https://pipelines.lsst.io/v/DM-FIXME
