### PR TITLE
DM-30869: Modernize MetricTask for better Gen 3 workflow

### DIFF
--- a/doc/lsst.verify/tasks/lsst.verify.tasks.MetricTask.rst
+++ b/doc/lsst.verify/tasks/lsst.verify.tasks.MetricTask.rst
@@ -70,9 +70,9 @@ Error Handling
 In general, a ``MetricTask`` may run in three cases:
 
 #. the task can compute the metric without incident.
-#. the task does not have the datasets required to compute the metric.
-   This often happens if the user runs generic metric configurations on arbitrary pipelines, or if they make changes to the pipeline configuration that enable or disable processing steps.
-   More rarely, it can happen when trying to compute diagnostic metrics on incomplete (i.e., failed) pipeline runs.
+#. the task does not have the data required to compute the metric.
+   This can happen with metadata- or table-based metrics if the user runs generic metric configurations on arbitrary pipelines, or if they make changes to the pipeline configuration that enable or disable processing steps.
+   Middleware automatically handles the case where an entire dataset is missing.
 #. the task has the data it needs, but cannot compute the metric.
    This could be because the data are corrupted, because the selected algorithm fails, or because the metric is ill-defined given the data.
 
@@ -82,5 +82,5 @@ A task that cannot give a valid result (case 3) must raise `~lsst.verify.tasks.M
 
 In grey areas, developers should choose a ``MetricTask``'s behavior based on whether the root cause is closer to case 2 or case 3.
 For example, :lsst-task:`~lsst.verify.tasks.commonMetrics.TimingMetricTask` accepts top-level task metadata as input, but returns `None` if it can't find metadata for the subtask it is supposed to time.
-While the input dataset is available, the subtask metadata are most likely missing because the subtask was never run, making the situation equivalent to case 2.
+The subtask metadata are most likely missing because the subtask was never run, making the situation equivalent to case 2.
 On the other hand, metadata with nonsense values falls squarely under case 3.

--- a/doc/lsst.verify/tasks/lsst.verify.tasks.MetricTask.rst
+++ b/doc/lsst.verify/tasks/lsst.verify.tasks.MetricTask.rst
@@ -77,7 +77,7 @@ In general, a ``MetricTask`` may run in three cases:
    This could be because the data are corrupted, because the selected algorithm fails, or because the metric is ill-defined given the data.
 
 A ``MetricTask`` must distinguish between these cases so that calling frameworks can handle them appropriately.
-A task for a metric that does not apply to a particular pipeline run (case 2) must return `None` in place of a `~lsst.verify.Measurement`.
+A task for a metric that does not apply to a particular pipeline run (case 2) must either raise `~lsst.pipe.base.NoWorkFound` or return `None`; it must not return a dummy value or raise a different exception.
 A task that cannot give a valid result (case 3) must raise `~lsst.verify.tasks.MetricComputationError`.
 
 In grey areas, developers should choose a ``MetricTask``'s behavior based on whether the root cause is closer to case 2 or case 3.

--- a/python/lsst/verify/tasks/apdbMetricTask.py
+++ b/python/lsst/verify/tasks/apdbMetricTask.py
@@ -29,8 +29,7 @@ from lsst.pex.config import Config, ConfigurableField, ConfigurableInstance, \
 from lsst.pipe.base import NoWorkFound, Task, Struct, connectionTypes
 from lsst.dax.apdb import make_apdb, ApdbConfig
 
-from lsst.verify.tasks import MetricTask, MetricConfig, MetricConnections, \
-    MetricComputationError
+from lsst.verify.tasks import MetricTask, MetricConfig, MetricConnections
 
 
 class ConfigApdbLoader(Task):
@@ -344,16 +343,11 @@ class ApdbMetricTask(MetricTask):
 
         This specialization of runQuantum passes the output data ID to `run`.
         """
-        try:
-            inputs = butlerQC.get(inputRefs)
-            outputs = self.run(**inputs,
-                               outputDataId=outputRefs.measurement.dataId)
-            if outputs.measurement is not None:
-                butlerQC.put(outputs, outputRefs)
-            else:
-                self.log.debug("Skipping measurement of %r on %s "
-                               "as not applicable.", self, inputRefs)
-        except MetricComputationError:
-            self.log.error(
-                "Measurement of %r failed on %s->%s",
-                self, inputRefs, outputRefs, exc_info=True)
+        inputs = butlerQC.get(inputRefs)
+        outputs = self.run(**inputs,
+                           outputDataId=outputRefs.measurement.dataId)
+        if outputs.measurement is not None:
+            butlerQC.put(outputs, outputRefs)
+        else:
+            self.log.debug("Skipping measurement of %r on %s "
+                           "as not applicable.", self, inputRefs)

--- a/python/lsst/verify/tasks/apdbMetricTask.py
+++ b/python/lsst/verify/tasks/apdbMetricTask.py
@@ -54,7 +54,7 @@ class ConfigApdbLoader(Task):
 
         Parameters
         ----------
-        config : `lsst.pex.config.Config` or `None`
+        config : `lsst.pex.config.Config`
             A config that may contain a `lsst.dax.apdb.ApdbConfig`.
             Behavior is undefined if there is more than one such member.
 
@@ -64,8 +64,6 @@ class ConfigApdbLoader(Task):
             A `lsst.dax.apdb.Apdb` object or a drop-in replacement, or `None`
             if no `lsst.dax.apdb.ApdbConfig` is present in ``config``.
         """
-        if config is None:
-            return None
         if isinstance(config, ApdbConfig):
             return make_apdb(config)
 
@@ -100,7 +98,7 @@ class ConfigApdbLoader(Task):
 
         Parameters
         ----------
-        configurable : `lsst.pex.config.ConfigurableInstance` or `None`
+        configurable : `lsst.pex.config.ConfigurableInstance`
             A configurable that may contain a `lsst.dax.apdb.ApdbConfig`.
 
         Returns
@@ -109,9 +107,6 @@ class ConfigApdbLoader(Task):
             A `lsst.dax.apdb.Apdb` object or a drop-in replacement, if a
             suitable config exists.
         """
-        if configurable is None:
-            return None
-
         if issubclass(configurable.ConfigClass, ApdbConfig):
             return configurable.apply()
         else:
@@ -122,7 +117,7 @@ class ConfigApdbLoader(Task):
 
         Parameters
         ----------
-        configDict: iterable of `lsst.pex.config.Config` or `None`
+        configDict: iterable of `lsst.pex.config.Config`
             A config iterable that may contain a `lsst.dax.apdb.ApdbConfig`.
 
         Returns
@@ -131,19 +126,17 @@ class ConfigApdbLoader(Task):
             A `lsst.dax.apdb.Apdb` object or a drop-in replacement, if a
             suitable config exists.
         """
-        if configDict:
-            for config in configDict:
-                result = self._getApdb(config)
-                if result:
-                    return result
-        return None
+        for config in configDict:
+            result = self._getApdb(config)
+            if result:
+                return result
 
     def run(self, config):
         """Create a database consistent with a science task config.
 
         Parameters
         ----------
-        config : `lsst.pex.config.Config` or `None`
+        config : `lsst.pex.config.Config`
             A config that should contain a `lsst.dax.apdb.ApdbConfig`.
             Behavior is undefined if there is more than one such member.
 
@@ -181,7 +174,7 @@ class DirectApdbLoader(Task):
 
         Parameters
         ----------
-        config : `lsst.dax.apdb.ApdbConfig` or `None`
+        config : `lsst.dax.apdb.ApdbConfig`
             A config for the database connection.
 
         Returns
@@ -219,6 +212,7 @@ class ApdbMetricConnections(
             "by AP processing.",
         storageClass="Config",
         multiple=True,
+        minimum=1,
         dimensions={"instrument", "visit", "detector"},
     )
     # Replaces MetricConnections.measurement, which is detector-level
@@ -326,11 +320,11 @@ class ApdbMetricTask(MetricTask):
         -----
         This implementation calls
         `~lsst.verify.tasks.ApdbMetricConfig.dbLoader` to acquire a database
-        handle (taking `None` if no input), then passes it and the value of
+        handle, then passes it and the value of
         ``outputDataId`` to `makeMeasurement`. The result of `makeMeasurement`
         is returned to the caller.
         """
-        db = self.dbLoader.run(dbInfo[0] if dbInfo else None).apdb
+        db = self.dbLoader.run(dbInfo[0]).apdb
 
         if db is not None:
             measurement = self.makeMeasurement(db, outputDataId)

--- a/python/lsst/verify/tasks/apdbMetricTask.py
+++ b/python/lsst/verify/tasks/apdbMetricTask.py
@@ -283,7 +283,7 @@ class ApdbMetricTask(MetricTask):
 
         Raises
         ------
-        MetricComputationError
+        lsst.verify.tasks.MetricComputationError
             Raised if an algorithmic or system error prevents calculation of
             the metric. See `run` for expected behavior.
         """
@@ -312,7 +312,7 @@ class ApdbMetricTask(MetricTask):
 
         Raises
         ------
-        MetricComputationError
+        lsst.verify.tasks.MetricComputationError
             Raised if an algorithmic or system error prevents calculation of
             the metric.
 

--- a/python/lsst/verify/tasks/commonMetrics.py
+++ b/python/lsst/verify/tasks/commonMetrics.py
@@ -130,7 +130,7 @@ class TimingMetricTask(MetadataMetricTask):
 
         Raises
         ------
-        MetricComputationError
+        lsst.verify.tasks.MetricComputationError
             Raised if the timing metadata are invalid.
         """
         if timings["StartTime"] is not None or timings["EndTime"] is not None:
@@ -226,7 +226,7 @@ class MemoryMetricTask(MetadataMetricTask):
 
         Raises
         ------
-        MetricComputationError
+        lsst.verify.tasks.MetricComputationError
             Raised if the memory metadata are invalid.
         """
         if memory["EndMemory"] is not None:

--- a/python/lsst/verify/tasks/commonMetrics.py
+++ b/python/lsst/verify/tasks/commonMetrics.py
@@ -34,6 +34,7 @@ import sys
 import astropy.units as u
 
 import lsst.pex.config as pexConfig
+from lsst.pipe.base import NoWorkFound
 
 from lsst.verify import Measurement, Datum
 from lsst.verify.tasks import MetricComputationError, MetadataMetricTask, \
@@ -125,13 +126,15 @@ class TimingMetricTask(MetadataMetricTask):
 
         Returns
         -------
-        measurement : `lsst.verify.Measurement` or `None`
+        measurement : `lsst.verify.Measurement`
             The running time of the target method.
 
         Raises
         ------
         lsst.verify.tasks.MetricComputationError
             Raised if the timing metadata are invalid.
+        lsst.pipe.base.NoWorkFound
+            Raised if no matching timing metadata found.
         """
         if timings["StartTime"] is not None or timings["EndTime"] is not None:
             try:
@@ -148,9 +151,7 @@ class TimingMetricTask(MetadataMetricTask):
                     meas.extras["end"] = Datum(timings["EndTimestamp"])
                 return meas
         else:
-            self.log.info("Nothing to do: no timing information for %s found.",
-                          self.config.target)
-            return None
+            raise NoWorkFound(f"Nothing to do: no timing information for {self.config.target} found.")
 
 
 # Expose MemoryMetricConfig name because config-writers expect it
@@ -221,13 +222,15 @@ class MemoryMetricTask(MetadataMetricTask):
 
         Returns
         -------
-        measurement : `lsst.verify.Measurement` or `None`
+        measurement : `lsst.verify.Measurement`
             The maximum memory usage of the target method.
 
         Raises
         ------
         lsst.verify.tasks.MetricComputationError
             Raised if the memory metadata are invalid.
+        lsst.pipe.base.NoWorkFound
+            Raised if no matching memory metadata found.
         """
         if memory["EndMemory"] is not None:
             try:
@@ -242,9 +245,7 @@ class MemoryMetricTask(MetadataMetricTask):
                 meas.notes['estimator'] = 'utils.timer.timeMethod'
                 return meas
         else:
-            self.log.info("Nothing to do: no memory information for %s found.",
-                          self.config.target)
-            return None
+            raise NoWorkFound(f"Nothing to do: no memory information for {self.config.target} found.")
 
     def _addUnits(self, memory, version):
         """Represent memory usage in correct units.

--- a/python/lsst/verify/tasks/metadataMetricTask.py
+++ b/python/lsst/verify/tasks/metadataMetricTask.py
@@ -256,6 +256,10 @@ class MetadataMetricTask(AbstractMetadataMetricTask):
         lsst.verify.tasks.MetricComputationError
             Raised if an algorithmic or system error prevents calculation of
             the metric. See `run` for expected behavior.
+        lsst.pipe.base.NoWorkFound
+            Raised if the metric is ill-defined or otherwise inapplicable.
+            Typically this means that the pipeline step or option being
+            measured was not run.
         """
 
     def run(self, metadata):
@@ -281,6 +285,10 @@ class MetadataMetricTask(AbstractMetadataMetricTask):
         lsst.verify.tasks.MetricComputationError
             Raised if the strings returned by `getInputMetadataKeys` match
             more than one key in any metadata object.
+        lsst.pipe.base.NoWorkFound
+            Raised if the metric is ill-defined or otherwise inapplicable.
+            Typically this means that the pipeline step or option being
+            measured was not run.
 
         Notes
         -----

--- a/python/lsst/verify/tasks/metadataMetricTask.py
+++ b/python/lsst/verify/tasks/metadataMetricTask.py
@@ -120,10 +120,6 @@ class AbstractMetadataMetricTask(MetricTask):
     -----
     This class should be customized by overriding `getInputMetadataKeys`
     and `run`.
-
-    This class makes no assumptions about how to handle missing data;
-    `run` may be called with `None` values, and is responsible
-    for deciding how to deal with them.
     """
     # Design note: getInputMetadataKeys and MetadataMetricTask.makeMeasurement
     # are overrideable methods rather than subtask(s) to keep the configs for
@@ -180,7 +176,7 @@ class AbstractMetadataMetricTask(MetricTask):
         Parameters
         ----------
         metadata : `lsst.pipe.base.TaskMetadata`
-            A metadata object, assumed not `None`.
+            A metadata object.
         metadataKeys : `dict` [`str`, `str`]
             Keys are arbitrary labels, values are metadata keys (or their
             substrings) in the format of
@@ -229,10 +225,6 @@ class MetadataMetricTask(AbstractMetadataMetricTask):
     -----
     This class should be customized by overriding `getInputMetadataKeys`
     and `makeMeasurement`. You should not need to override `run`.
-
-    This class makes no assumptions about how to handle missing data;
-    `makeMeasurement` may be called with `None` values, and is responsible
-    for deciding how to deal with them.
     """
     # Design note: getInputMetadataKeys and makeMeasurement are overrideable
     # methods rather than subtask(s) to keep the configs for
@@ -271,7 +263,7 @@ class MetadataMetricTask(AbstractMetadataMetricTask):
 
         Parameters
         ----------
-        metadata : `lsst.pipe.base.TaskMetadata` or `None`
+        metadata : `lsst.pipe.base.TaskMetadata`
             A metadata object for the unit of science processing to use for
             this metric, or a collection of such objects if this task combines
             many units of processing into a single metric.
@@ -299,9 +291,6 @@ class MetadataMetricTask(AbstractMetadataMetricTask):
         """
         metadataKeys = self.getInputMetadataKeys(self.config)
 
-        if metadata is not None:
-            data = self.extractMetadata(metadata, metadataKeys)
-        else:
-            data = {dataName: None for dataName in metadataKeys}
+        data = self.extractMetadata(metadata, metadataKeys)
 
         return Struct(measurement=self.makeMeasurement(data))

--- a/python/lsst/verify/tasks/metricTask.py
+++ b/python/lsst/verify/tasks/metricTask.py
@@ -142,7 +142,9 @@ class MetricTask(pipeBase.PipelineTask, metaclass=abc.ABCMeta):
             - ``measurement``: the value of the metric
               (`lsst.verify.Measurement` or `None`). This method is not
               responsible for adding mandatory metadata (e.g., the data ID);
-              this is handled by the caller.
+              this is handled by the caller. `None` may be used to indicate
+              that a metric is undefined or irrelevant instead of raising
+              `~lsst.pipe.base.NoWorkFound`.
 
         Raises
         ------
@@ -154,13 +156,12 @@ class MetricTask(pipeBase.PipelineTask, metaclass=abc.ABCMeta):
             more specific exception describing the root cause.
 
             Not having enough data for a metric to be applicable is not an
-            error, and should not trigger this exception.
-
-        Notes
-        -----
-        If a metric cannot be calculated because
-        the necessary inputs are missing, the ``MetricTask`` must return `None`
-        in place of the measurement.
+            error, and should raise ``NoWorkFound`` (see below) instead of
+            this exception.
+        lsst.pipe.base.NoWorkFound
+            Raised if the metric is ill-defined or otherwise inapplicable to
+            the data. Typically this means that the pipeline step or option
+            being measured was not run.
         """
 
     def runQuantum(self, butlerQC, inputRefs, outputRefs):

--- a/python/lsst/verify/tasks/metricTask.py
+++ b/python/lsst/verify/tasks/metricTask.py
@@ -158,9 +158,7 @@ class MetricTask(pipeBase.PipelineTask, metaclass=abc.ABCMeta):
 
         Notes
         -----
-        All input data must be treated as optional. This maximizes the
-        ``MetricTask``'s usefulness for incomplete pipeline runs or runs with
-        optional processing steps. If a metric cannot be calculated because
+        If a metric cannot be calculated because
         the necessary inputs are missing, the ``MetricTask`` must return `None`
         in place of the measurement.
         """

--- a/python/lsst/verify/tasks/metricTask.py
+++ b/python/lsst/verify/tasks/metricTask.py
@@ -168,19 +168,13 @@ class MetricTask(pipeBase.PipelineTask, metaclass=abc.ABCMeta):
         """Do Butler I/O to provide in-memory objects for run.
 
         This specialization of runQuantum performs error-handling specific to
-        MetricTasks. Most or all of this functionality may be moved to
-        activators in the future.
+        MetricTasks.
         """
         # Synchronize changes to this method with ApdbMetricTask
-        try:
-            inputs = butlerQC.get(inputRefs)
-            outputs = self.run(**inputs)
-            if outputs.measurement is not None:
-                butlerQC.put(outputs, outputRefs)
-            else:
-                self.log.debug("Skipping measurement of %r on %s "
-                               "as not applicable.", self, inputRefs)
-        except MetricComputationError:
-            self.log.error(
-                "Measurement of %r failed on %s->%s",
-                self, inputRefs, outputRefs, exc_info=True)
+        inputs = butlerQC.get(inputRefs)
+        outputs = self.run(**inputs)
+        if outputs.measurement is not None:
+            butlerQC.put(outputs, outputRefs)
+        else:
+            self.log.debug("Skipping measurement of %r on %s "
+                           "as not applicable.", self, inputRefs)

--- a/python/lsst/verify/tasks/testUtils.py
+++ b/python/lsst/verify/tasks/testUtils.py
@@ -124,17 +124,14 @@ class MetadataMetricTestCase(MetricTaskTestCase):
 
                 self.task.run(metadata1)
                 mockWorkhorse.assert_called_once_with({"unused": 42})
-                mockWorkhorse.reset_mock()
-                self.task.run(None)
-                mockWorkhorse.assert_called_once_with({"unused": None})
             else:
                 metadata1 = TaskMetadata()
                 metadata1[mockKey] = 42
                 metadata2 = TaskMetadata()
                 metadata2[mockKey] = "Sphere"
-                self.task.run([metadata1, None, metadata2])
+                self.task.run([metadata1, metadata2])
                 mockWorkhorse.assert_called_once_with(
-                    [{"unused": value} for value in [42, None, "Sphere"]])
+                    [{"unused": value} for value in [42, "Sphere"]])
 
     def testAmbiguousRun(self):
         mockKey = "unitTestKey"
@@ -152,11 +149,13 @@ class MetadataMetricTestCase(MetricTaskTestCase):
     def testPassThroughRun(self):
         with patch.object(self.task, "makeMeasurement",
                           side_effect=MetricComputationError):
+            metadata1 = TaskMetadata()
+            metadata1["unitTestKey"] = 42
             with self.assertRaises(MetricComputationError):
                 if self._takesScalarMetadata(self.task):
-                    self.task.run(None)
+                    self.task.run(metadata1)
                 else:
-                    self.task.run([None])
+                    self.task.run([metadata1])
 
     def testDimensionsOverride(self):
         config = self.task.config

--- a/tests/test_apdbMetricTask.py
+++ b/tests/test_apdbMetricTask.py
@@ -31,7 +31,7 @@ import lsst.daf.butler.tests as butlerTests
 from lsst.pipe.base import Task, Struct, testUtils
 
 from lsst.verify import Measurement
-from lsst.verify.tasks import ApdbMetricTask, MetricComputationError
+from lsst.verify.tasks import ApdbMetricTask
 from lsst.verify.tasks.testUtils import ApdbMetricTestCase
 
 
@@ -155,24 +155,6 @@ class Gen3ApdbTestSuite(ApdbMetricTestCase):
                 lsst.pipe.base.ButlerQuantumContext, "put") as put:
             testUtils.runTestQuantum(task, butler, quantum, mockRun=False)
             # Should not attempt to write nonexistent data
-            put.assert_not_called()
-
-    def testRunQuantumException(self):
-        class ExceptionalTask(DummyTask):
-            def run(self, *args, **kwargs):
-                raise MetricComputationError()
-
-        config = ExceptionalTask.ConfigClass()
-        config.connections.package = "verify"
-        config.connections.metric = "DummyApdb"
-        task = ExceptionalTask(config=config)
-        butler, quantum, input = self._prepareQuantum(task)
-
-        with unittest.mock.patch.object(
-                lsst.pipe.base.ButlerQuantumContext, "put") as put:
-            testUtils.runTestQuantum(task, butler, quantum, mockRun=False)
-            # Should not propagate MetricComputationError
-            # Should not attempt to write data that was never returned
             put.assert_not_called()
 
 

--- a/tests/test_commonMetrics.py
+++ b/tests/test_commonMetrics.py
@@ -81,10 +81,16 @@ class TimingMetricTestSuite(MetadataMetricTestCase):
     def testRunDifferentMethod(self):
         self.config.target = DummyTask._DefaultName + ".runDataRef"
         task = TimingMetricTask(config=self.config)
-        result = task.run(self.scienceTask.getFullMetadata())
-        lsst.pipe.base.testUtils.assertValidOutput(task, result)
-        meas = result.measurement
-        self.assertIsNone(meas)
+        try:
+            result = task.run(self.scienceTask.getFullMetadata())
+        except lsst.pipe.base.NoWorkFound:
+            # Correct behavior
+            pass
+        else:
+            # Alternative correct behavior
+            lsst.pipe.base.testUtils.assertValidOutput(task, result)
+            meas = result.measurement
+            self.assertIsNone(meas)
 
     def testNonsenseKeys(self):
         metadata = self.scienceTask.getFullMetadata()
@@ -145,10 +151,16 @@ class MemoryMetricTestSuite(MetadataMetricTestCase):
     def testRunDifferentMethod(self):
         self.config.target = DummyTask._DefaultName + ".runDataRef"
         task = MemoryMetricTask(config=self.config)
-        result = task.run(self.scienceTask.getFullMetadata())
-        lsst.pipe.base.testUtils.assertValidOutput(task, result)
-        meas = result.measurement
-        self.assertIsNone(meas)
+        try:
+            result = task.run(self.scienceTask.getFullMetadata())
+        except lsst.pipe.base.NoWorkFound:
+            # Correct behavior
+            pass
+        else:
+            # Alternative correct behavior
+            lsst.pipe.base.testUtils.assertValidOutput(task, result)
+            meas = result.measurement
+            self.assertIsNone(meas)
 
     def testBadlyTypedKeys(self):
         metadata = self.scienceTask.getFullMetadata()

--- a/tests/test_commonMetrics.py
+++ b/tests/test_commonMetrics.py
@@ -78,12 +78,6 @@ class TimingMetricTestSuite(MetadataMetricTestCase):
         self.assertGreater(meas.quantity, 0.0 * u.second)
         self.assertLess(meas.quantity, 2 * DummyTask.taskLength * u.second)
 
-    def testMissingData(self):
-        result = self.task.run(None)
-        lsst.pipe.base.testUtils.assertValidOutput(self.task, result)
-        meas = result.measurement
-        self.assertIsNone(meas)
-
     def testRunDifferentMethod(self):
         self.config.target = DummyTask._DefaultName + ".runDataRef"
         task = TimingMetricTask(config=self.config)
@@ -147,12 +141,6 @@ class MemoryMetricTestSuite(MetadataMetricTestCase):
         self.assertIsInstance(meas, Measurement)
         self.assertEqual(meas.metric_name, self.metric)
         self.assertGreater(meas.quantity, 0.0 * u.byte)
-
-    def testMissingData(self):
-        result = self.task.run(None)
-        lsst.pipe.base.testUtils.assertValidOutput(self.task, result)
-        meas = result.measurement
-        self.assertIsNone(meas)
 
     def testRunDifferentMethod(self):
         self.config.target = DummyTask._DefaultName + ".runDataRef"

--- a/tests/test_configApdbLoader.py
+++ b/tests/test_configApdbLoader.py
@@ -50,10 +50,6 @@ class ConfigApdbLoaderTestSuite(lsst.utils.tests.TestCase):
     def setUp(self):
         self.task = ConfigApdbLoader()
 
-    def testNoConfig(self):
-        result = self.task.run(None)
-        self.assertIsNone(result.apdb)
-
     def testEmptyConfig(self):
         result = self.task.run(Config())
         self.assertIsNone(result.apdb)

--- a/tests/test_directApdbLoader.py
+++ b/tests/test_directApdbLoader.py
@@ -38,10 +38,6 @@ class DirectApdbLoaderTestSuite(lsst.utils.tests.TestCase):
     def setUp(self):
         self.task = DirectApdbLoader()
 
-    def testNoConfig(self):
-        result = self.task.run(None)
-        self.assertIsNone(result.apdb)
-
     def testValidConfig(self):
         result = self.task.run(self._dummyApdbConfig())
         self.assertIsInstance(result.apdb, Apdb)


### PR DESCRIPTION
This PR removes some unused features from `MetricTask`, namely the requirements that subclasses accept `None` input and built-in handling of `MetricComputationError`. These changes significantly simplify subclass code and bring `MetricTask` closer in line with current `PipelineTask` conventions.