### PR TITLE
DM-37302: lsst.verify.TimingMetricTask does not return wall-clock time

### DIFF
--- a/doc/lsst.verify/tasks/lsst.verify.tasks.CpuTimingMetricTask.rst
+++ b/doc/lsst.verify/tasks/lsst.verify.tasks.CpuTimingMetricTask.rst
@@ -1,0 +1,84 @@
+.. lsst-task-topic:: lsst.verify.tasks.commonMetrics.CpuTimingMetricTask
+
+###################
+CpuTimingMetricTask
+###################
+
+``CpuTimingMetricTask`` creates a CPU timing `~lsst.verify.Measurement` based on data collected by @\ `~lsst.utils.timer.timeMethod`.
+It reads the raw timing data from the top-level `~lsst.pipe.base.PipelineTask`'s metadata, which is identified by the task configuration.
+
+This task always returns a smaller value than :lsst-task:`lsst.verify.tasks.commonMetrics.TimingMetricTask`.
+If it is *much* smaller, that may be a sign that the task is running inefficiently, since both metrics are normally run on task methods that don't perform I/O.
+
+.. _lsst.verify.tasks.CpuTimingMetricTask-summary:
+
+Processing summary
+==================
+
+``CpuTimingMetricTask`` searches the metadata for @\ `~lsst.utils.timer.timeMethod`-generated keys corresponding to the method of interest.
+If it finds matching keys, it stores the elapsed time as a `~lsst.verify.Measurement`.
+
+.. _lsst.verify.tasks.CpuTimingMetricTask-api:
+
+Python API summary
+==================
+
+.. lsst-task-api-summary:: lsst.verify.tasks.commonMetrics.CpuTimingMetricTask
+
+.. _lsst.verify.tasks.CpuTimingMetricTask-butler:
+
+Butler datasets
+===============
+
+Input datasets
+--------------
+
+``metadata``
+    The metadata of the top-level pipeline task (e.g., ``CharacterizeImageTask``, ``DiaPipeTask``) being instrumented.
+    This connection is usually configured indirectly through the ``labelName`` template as ``"{labelName}_metadata"``.
+
+Output datasets
+---------------
+
+``measurement``
+    The value of the metric.
+    The dataset type should not be configured directly, but should be set
+    changing the ``package`` and ``metric`` template variables to the metric's
+    namespace (package, by convention) and in-package name, respectively.
+    Subclasses that only support one metric should set these variables
+    automatically.
+
+.. _lsst.verify.tasks.CpuTimingMetricTask-subtasks:
+
+Retargetable subtasks
+=====================
+
+.. lsst-task-config-subtasks:: lsst.verify.tasks.commonMetrics.CpuTimingMetricTask
+
+.. _lsst.verify.tasks.CpuTimingMetricTask-configs:
+
+Configuration fields
+====================
+
+.. lsst-task-config-fields:: lsst.verify.tasks.commonMetrics.CpuTimingMetricTask
+
+.. _lsst.verify.tasks.CpuTimingMetricTask-examples:
+
+Examples
+========
+
+.. code-block:: py
+
+   from lsst.verify.tasks import CpuTimingMetricTask
+
+   config = CpuTimingMetricTask.ConfigClass()
+   config.connections.labelName = "diaPipe"
+   config.connections.package = "ap_association"
+   cofig.connections.metric = "DiaForcedSourceCpuTime"
+   config.target = "diaPipe:diaForcedSource.run"
+   task = CpuTimingMetricTask(config=config)
+
+   # config.connections provided for benefit of Pipeline
+   # but since we've defined it we might as well use it
+   metadata = butler.get(config.connections.metadata)
+   processCcdTime = task.run(metadata).measurement

--- a/doc/lsst.verify/tasks/lsst.verify.tasks.MemoryMetricTask.rst
+++ b/doc/lsst.verify/tasks/lsst.verify.tasks.MemoryMetricTask.rst
@@ -37,6 +37,7 @@ Input datasets
 
 ``metadata``
     The metadata of the top-level pipeline task (e.g., ``CharacterizeImageTask``, ``DiaPipeTask``) being instrumented.
+    This connection is usually configured indirectly through the ``labelName`` template as ``"{labelName}_metadata"``.
 
 Output datasets
 ---------------
@@ -73,10 +74,10 @@ Examples
    from lsst.verify.tasks import MemoryMetricTask
 
    config = MemoryMetricTask.ConfigClass()
-   config.connections.metadata = "apPipe_metadata"
-   config.connections.package = "pipe_tasks"
-   cofig.connections.metric = "ProcessCcdMemory"
-   config.target = "apPipe:ccdProcessor.runDataRef"
+   config.connections.labelName = "diaPipe"
+   config.connections.package = "ap_association"
+   cofig.connections.metric = "DiaForcedSourceMemory"
+   config.target = "diaPipe:diaForcedSource.run"
    task = MemoryMetricTask(config=config)
 
    # config.connections provided for benefit of Pipeline

--- a/doc/lsst.verify/tasks/lsst.verify.tasks.MetadataMetricTask.rst
+++ b/doc/lsst.verify/tasks/lsst.verify.tasks.MetadataMetricTask.rst
@@ -35,6 +35,7 @@ Input datasets
 
 `metadata``
     The metadata of the top-level pipeline task (e.g., ``CharacterizeImageTask``, ``DiaPipeTask``) being instrumented.
+    This connection is usually configured indirectly through the ``labelName`` template as ``"{labelName}_metadata"``.
 
 Output datasets
 ---------------

--- a/doc/lsst.verify/tasks/lsst.verify.tasks.TimingMetricTask.rst
+++ b/doc/lsst.verify/tasks/lsst.verify.tasks.TimingMetricTask.rst
@@ -32,6 +32,7 @@ Input datasets
 
 ``metadata``
     The metadata of the top-level pipeline task (e.g., ``CharacterizeImageTask``, ``DiaPipeTask``) being instrumented.
+    This connection is usually configured indirectly through the ``labelName`` template as ``"{labelName}_metadata"``.
 
 Output datasets
 ---------------
@@ -68,10 +69,10 @@ Examples
    from lsst.verify.tasks import TimingMetricTask
 
    config = TimingMetricTask.ConfigClass()
-   config.connections.metadata = "apPipe_metadata"
-   config.connections.package = "pipe_tasks"
-   cofig.connections.metric = "ProcessCcdTime"
-   config.target = "apPipe:ccdProcessor.runDataRef"
+   config.connections.labelName = "diaPipe"
+   config.connections.package = "ap_association"
+   cofig.connections.metric = "DiaForcedSourceTime"
+   config.target = "diaPipe:diaForcedSource.run"
    task = TimingMetricTask(config=config)
 
    # config.connections provided for benefit of Pipeline

--- a/tests/test_commonMetrics.py
+++ b/tests/test_commonMetrics.py
@@ -62,7 +62,6 @@ class TimingMetricTestSuite(MetadataMetricTestCase):
 
     def setUp(self):
         super().setUp()
-        self.config = TimingMetricTestSuite._standardConfig()
         self.metric = Name("verify.DummyTime")
 
         self.scienceTask = DummyTask()
@@ -79,8 +78,9 @@ class TimingMetricTestSuite(MetadataMetricTestCase):
         self.assertLess(meas.quantity, 2 * DummyTask.taskLength * u.second)
 
     def testRunDifferentMethod(self):
-        self.config.target = DummyTask._DefaultName + ".runDataRef"
-        task = TimingMetricTask(config=self.config)
+        config = self._standardConfig()
+        config.target = DummyTask._DefaultName + ".runDataRef"
+        task = TimingMetricTask(config=config)
         try:
             result = task.run(self.scienceTask.getFullMetadata())
         except lsst.pipe.base.NoWorkFound:
@@ -100,9 +100,8 @@ class TimingMetricTestSuite(MetadataMetricTestCase):
         for key in startKeys:
             del metadata[key]
 
-        task = TimingMetricTask(config=self.config)
         with self.assertRaises(MetricComputationError):
-            task.run(metadata)
+            self.task.run(metadata)
 
     def testBadlyTypedKeys(self):
         metadata = self.scienceTask.getFullMetadata()
@@ -112,9 +111,8 @@ class TimingMetricTestSuite(MetadataMetricTestCase):
         for key in endKeys:
             metadata[key] = str(float(metadata[key]))
 
-        task = TimingMetricTask(config=self.config)
         with self.assertRaises(MetricComputationError):
-            task.run(metadata)
+            self.task.run(metadata)
 
 
 class MemoryMetricTestSuite(MetadataMetricTestCase):
@@ -133,7 +131,6 @@ class MemoryMetricTestSuite(MetadataMetricTestCase):
 
     def setUp(self):
         super().setUp()
-        self.config = self._standardConfig()
         self.metric = Name("verify.DummyMemory")
 
         self.scienceTask = DummyTask()
@@ -149,8 +146,9 @@ class MemoryMetricTestSuite(MetadataMetricTestCase):
         self.assertGreater(meas.quantity, 0.0 * u.byte)
 
     def testRunDifferentMethod(self):
-        self.config.target = DummyTask._DefaultName + ".runDataRef"
-        task = MemoryMetricTask(config=self.config)
+        config = self._standardConfig()
+        config.target = DummyTask._DefaultName + ".runDataRef"
+        task = MemoryMetricTask(config=config)
         try:
             result = task.run(self.scienceTask.getFullMetadata())
         except lsst.pipe.base.NoWorkFound:
@@ -170,9 +168,8 @@ class MemoryMetricTestSuite(MetadataMetricTestCase):
         for key in endKeys:
             metadata[key] = str(float(metadata[key]))
 
-        task = MemoryMetricTask(config=self.config)
         with self.assertRaises(MetricComputationError):
-            task.run(metadata)
+            self.task.run(metadata)
 
     def testOldMetadata(self):
         """Test compatibility with version 0 metadata

--- a/tests/test_commonMetrics.py
+++ b/tests/test_commonMetrics.py
@@ -96,7 +96,7 @@ class TimingMetricTestSuite(MetadataMetricTestCase):
         metadata = self.scienceTask.getFullMetadata()
         startKeys = [key
                      for key in metadata.paramNames(topLevelOnly=False)
-                     if "StartCpuTime" in key]
+                     if "StartUtc" in key]
         for key in startKeys:
             del metadata[key]
 
@@ -107,9 +107,9 @@ class TimingMetricTestSuite(MetadataMetricTestCase):
         metadata = self.scienceTask.getFullMetadata()
         endKeys = [key
                    for key in metadata.paramNames(topLevelOnly=False)
-                   if "EndCpuTime" in key]
+                   if "EndUtc" in key]
         for key in endKeys:
-            metadata[key] = str(float(metadata[key]))
+            metadata[key] = 42
 
         with self.assertRaises(MetricComputationError):
             self.task.run(metadata)
@@ -145,6 +145,12 @@ class CpuTimingMetricTestSuite(MetadataMetricTestCase):
         self.assertEqual(meas.metric_name, self.metric)
         self.assertGreater(meas.quantity, 0.0 * u.second)
         self.assertLess(meas.quantity, 2 * DummyTask.taskLength * u.second)
+
+        # CPU time should be less than wall-clock time.
+        wallClock = TimingMetricTask(config=TimingMetricTestSuite._standardConfig())
+        wallResult = wallClock.run(self.scienceTask.getFullMetadata())
+        # Include 0.1% margin for almost-equal values.
+        self.assertLess(meas.quantity, 1.001 * wallResult.measurement.quantity)
 
     def testRunDifferentMethod(self):
         config = self._standardConfig()


### PR DESCRIPTION
This PR fixes the implementation of `TimingMetricTask` to return the wall-clock time, as advertised, instead of the CPU time. It creates a new task, `CpuTimingMetricTask`, that preserves the old implementation under a more accurate name.