### PR TITLE
DM-23416: Fix units formatting error in verify.job report

### DIFF
--- a/python/lsst/verify/bin/inspectjob.py
+++ b/python/lsst/verify/bin/inspectjob.py
@@ -121,7 +121,10 @@ def inspect_job(job):
 
     print("\nMeasurements:")
     for metric, measurement in job.measurements.items():
-        pretty_quantity = measurement.quantity.round(4)
+        if (measurement.quantity.value < 1e-2):
+            pretty_quantity = '{0.value:0.2e} {0.unit}'.format(measurement.quantity)
+        else:
+            pretty_quantity = '{0.value:0.2f} {0.unit}'.format(measurement.quantity)
         if measurement.notes:
             prefix = str(measurement.metric_name) + "."
             # Raw representation of measurement.notes hard to read

--- a/python/lsst/verify/measurement.py
+++ b/python/lsst/verify/measurement.py
@@ -249,7 +249,11 @@ class Measurement(JsonSerializationMixin):
         rep : `str`
             String representation.
         """
-        return '{0.value:0.1f} {0.unit:latex_inline}'.format(self.quantity)
+        # If the value is less than 0.01, represent in scientific notation
+        if (self.quantity.value < 1e-2):
+            return '{0.value:0.2e} {0.unit:latex_inline}'.format(self.quantity)
+        else:
+            return '{0.value:0.2f} {0.unit:latex_inline}'.format(self.quantity)
 
     @property
     def description(self):


### PR DESCRIPTION
For metrics with very small values (e.g. 1e-6 or 1e-7, as expected for ellipticity residuals), `inspect_job.py` and the formatting in `verify.Measurement` reported those metrics as 0.0. This ticket fixes it so tiny metric values will appear fine in screen outputs.

****

- [ ] Passes Jenkins CI.
- [ ] Documentation is up-to-date.

Preview the docs at: https://pipelines.lsst.io/v/DM-FIXME
