### PR TITLE
DM-38210: Use butler.get() rather than deprecated getDirect()

### DIFF
--- a/python/lsst/verify/bin/jobReporter.py
+++ b/python/lsst/verify/bin/jobReporter.py
@@ -116,9 +116,8 @@ class JobReporter:
                 collections=self.collection,
                 findFirst=True))
             for ref in datasetRefs:
-                # getDirect skips dataset resolution; ref is guaranteed to
-                # be valid.
-                m = self.butler.getDirect(ref)
+                # Ref is guaranteed to be valid.
+                m = self.butler.get(ref)
                 # make the name the same as what SQuaSH Expects
                 m.metric_name = metric
 

--- a/python/lsst/verify/extract_metricvalues.py
+++ b/python/lsst/verify/extract_metricvalues.py
@@ -263,7 +263,7 @@ def load_from_butler(butler, query, reject_suffix=None, verbose=False):
         # We only want one of each, so we need findFirst.
         datasets = set(butler.registry.queryDatasets(metric, findFirst=True))
         for dataset in datasets:
-            value = butler.getDirect(dataset)
+            value = butler.get(dataset)
             data_ids.add(dataset.dataId)
             result[(dataset.dataId, metric.name)] = value
 


### PR DESCRIPTION
Requires lsst/daf_butler#797

****

- [ ] Passes Jenkins CI.
- [ ] Documentation is up-to-date.

Preview the docs at: https://pipelines.lsst.io/v/DM-FIXME
