### PR TITLE
Revert "DM-38953: Adopt now-supported approach to dynamic connections."

### DIFF
--- a/python/lsst/verify/tasks/metadataMetricTask.py
+++ b/python/lsst/verify/tasks/metadataMetricTask.py
@@ -73,15 +73,19 @@ class SingleMetadataMetricConnections(
         """
         super().__init__(config=config)
         if config and config.metadataDimensions != self.metadata.dimensions:
-            self.dimensions.clear()
-            self.dimensions.update(config.metadataDimensions)
-            self.metadata = connectionTypes.Input(
+            # Hack, but only way to get a connection without fixed dimensions
+            newMetadata = connectionTypes.Input(
                 name=self.metadata.name,
                 doc=self.metadata.doc,
                 storageClass=self.metadata.storageClass,
-                dimensions=frozenset(config.metadataDimensions),
+                dimensions=config.metadataDimensions,
                 multiple=self.metadata.multiple,
             )
+            self.metadata = newMetadata
+            # Registry must match actual connections
+            self.allConnections['metadata'] = self.metadata
+            # Task requires that quantum dimensions match input dimensions
+            self.dimensions = config.metadataDimensions
 
 
 class MetadataMetricConfig(


### PR DESCRIPTION
Reverts lsst/verify#111

See breakage discussion in https://lsstc.slack.com/archives/C2JPMCF5X/p1683754340587629