### PR TITLE
DM-39605: Use butler.dimensions rather than butler.registry.dimensions

### DIFF
--- a/tests/test_apdbMetricTask.py
+++ b/tests/test_apdbMetricTask.py
@@ -135,7 +135,7 @@ class Gen3ApdbTestSuite(ApdbMetricTestCase):
         # Did output data ID get passed to DummyTask.run?
         expectedId = lsst.daf.butler.DataCoordinate.standardize(
             {"instrument": self.CAMERA_ID},
-            universe=butler.registry.dimensions)
+            universe=butler.dimensions)
         run.assert_called_once_with(
             dbInfo=[input],
             outputDataId=expectedId)


### PR DESCRIPTION
{Summary of changes. Prefix PR title with ticket handle.}

****

- [ ] Passes Jenkins CI.
- [ ] Documentation is up-to-date.

Preview the docs at: https://pipelines.lsst.io/v/DM-FIXME
