### PR TITLE
DM-41846: Use the test ID as the unique component of the test run collection

### DIFF
--- a/tests/test_apdbMetricTask.py
+++ b/tests/test_apdbMetricTask.py
@@ -115,7 +115,7 @@ class Gen3ApdbTestSuite(ApdbMetricTestCase):
             "detector": self.CHIP_ID,
         }
 
-        butler = butlerTests.makeTestCollection(self.repo)
+        butler = butlerTests.makeTestCollection(self.repo, uniqueId=self.id())
         # task.config not persistable if it refers to a local class
         # We don't actually use the persisted config, so just make a new one
         info = task.ConfigClass()


### PR DESCRIPTION
This is a reasonable thing to do in general, but is important when using pytest-randomly because when using that plugin without the `--randomly-dont-reset-seed` flag, the seed is forced to the global value before every test is run. This leads to makeTestCollection returning the same random integer for every test and the runs clash in the shared repo.

****

- [ ] Passes Jenkins CI.
- [ ] Documentation is up-to-date.

Preview the docs at: https://pipelines.lsst.io/v/DM-FIXME
