### PR TITLE
DM-43414: Change how Apdb is instanciated by ApdbMetricTask

### DIFF
--- a/python/lsst/verify/tasks/apdbMetricTask.py
+++ b/python/lsst/verify/tasks/apdbMetricTask.py
@@ -27,7 +27,7 @@ import abc
 from lsst.pex.config import Config, ConfigurableField, ConfigurableInstance, \
     ConfigDictField, ConfigChoiceField, FieldValidationError
 from lsst.pipe.base import NoWorkFound, Task, Struct, connectionTypes
-from lsst.dax.apdb import make_apdb, ApdbConfig
+from lsst.dax.apdb import Apdb, ApdbConfig
 
 from lsst.verify.tasks import MetricTask, MetricConfig, MetricConnections
 
@@ -64,7 +64,7 @@ class ConfigApdbLoader(Task):
             if no `lsst.dax.apdb.ApdbConfig` is present in ``config``.
         """
         if isinstance(config, ApdbConfig):
-            return make_apdb(config)
+            return Apdb.from_config(config)
 
         for field in config.values():
             if isinstance(field, ConfigurableInstance):
@@ -184,7 +184,7 @@ class DirectApdbLoader(Task):
             ``apdb``
                 A database configured the same way as in ``config``.
         """
-        return Struct(apdb=(make_apdb(config) if config else None))
+        return Struct(apdb=(Apdb.from_config(config) if config else None))
 
 
 class ApdbMetricConnections(

--- a/tests/test_configApdbLoader.py
+++ b/tests/test_configApdbLoader.py
@@ -19,6 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import shutil
+import tempfile
 import unittest
 
 import lsst.utils.tests
@@ -41,14 +43,16 @@ class ConfigApdbLoaderTestSuite(lsst.utils.tests.TestCase):
         registry.register("bar", ApdbSql, ConfigClass=ApdbSqlConfig)
         return registry
 
-    @staticmethod
-    def _dummyApdbConfig():
-        config = ApdbSqlConfig()
-        config.db_url = "sqlite://"     # in-memory DB
-        return config
+    def _dummyApdbConfig(self):
+        return ApdbSql.init_database(db_url=self.db_url)
 
     def setUp(self):
+        self.tempdir = tempfile.mkdtemp()
+        self.db_url = f"sqlite:///{self.tempdir}/apdb.sqlite3"
         self.task = ConfigApdbLoader()
+
+    def tearDown(self):
+        shutil.rmtree(self.tempdir, ignore_errors=True)
 
     def testEmptyConfig(self):
         result = self.task.run(Config())

--- a/tests/test_directApdbLoader.py
+++ b/tests/test_directApdbLoader.py
@@ -19,24 +19,28 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import shutil
+import tempfile
 import unittest
 
 import lsst.utils.tests
-from lsst.dax.apdb import Apdb, ApdbSqlConfig
+from lsst.dax.apdb import Apdb, ApdbSql
 
 from lsst.verify.tasks import DirectApdbLoader
 
 
 class DirectApdbLoaderTestSuite(lsst.utils.tests.TestCase):
 
-    @staticmethod
-    def _dummyApdbConfig():
-        config = ApdbSqlConfig()
-        config.db_url = "sqlite://"     # in-memory DB
-        return config
+    def _dummyApdbConfig(self):
+        return ApdbSql.init_database(db_url=self.db_url)
 
     def setUp(self):
+        self.tempdir = tempfile.mkdtemp()
+        self.db_url = f"sqlite:///{self.tempdir}/apdb.sqlite3"
         self.task = DirectApdbLoader()
+
+    def tearDown(self):
+        shutil.rmtree(self.tempdir, ignore_errors=True)
 
     def testValidConfig(self):
         result = self.task.run(self._dummyApdbConfig())


### PR DESCRIPTION
Apdb API has changed the way how Apdb instances are created and how database is initialized. This patch updates code in ApdbMetricTask and unit tests for new Apdb API.

{Summary of changes. Prefix PR title with ticket handle.}

****

- [ ] Passes Jenkins CI.
- [ ] Documentation is up-to-date.

Preview the docs at: https://pipelines.lsst.io/v/DM-FIXME
