### PR TITLE
DM-49464: Use on-disk APDB for tests

### DIFF
--- a/tests/test_apdbMetricTask.py
+++ b/tests/test_apdbMetricTask.py
@@ -62,9 +62,11 @@ class Gen3ApdbTestSuite(ApdbMetricTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        apdb_config = daxApdb.ApdbSql.init_database(db_url="sqlite://")
+        sqlite_file = tempfile.NamedTemporaryFile()
+        cls.addClassCleanup(sqlite_file.close)
         cls.config_file = tempfile.NamedTemporaryFile()
         cls.addClassCleanup(cls.config_file.close)
+        apdb_config = daxApdb.ApdbSql.init_database(db_url=f"sqlite:///{sqlite_file.name}")
         apdb_config.save(cls.config_file.name)
 
         cls.CAMERA_ID = "NotACam"


### PR DESCRIPTION
In-memory SQLite APDB does not really work since some time already.

{Summary of changes. Prefix PR title with ticket handle.}

****

- [X] Passes Jenkins CI.
- [ ] Documentation is up-to-date.

Preview the docs at: https://pipelines.lsst.io/v/DM-FIXME
